### PR TITLE
Add equality operators (== and \!=) for explicit comparisons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,9 @@ RUST_BACKTRACE=1 cargo test  # Debug macro panics
 2. **Fork and peek pattern**: Using `fork()` to look ahead without consuming tokens is essential for complex parsing
 3. **Enum variant detection**: Checking if a path has multiple segments (e.g., `Status::Active` vs `Location`) helps distinguish enum variants from structs
 4. **Special handling for Option/Result**: Custom logic for `Some`, `None`, `Ok`, `Err` provides better error messages
+5. **NO EXPRESSIONS IN PATTERNS**: By design, we do NOT accept arbitrary expressions in pattern positions (e.g., `Some(vec![1, 2, 3])` is not allowed). This is a deliberate architectural choice that eliminates parsing ambiguities and enables our complex pattern syntax
+6. **Expressions after operators**: While patterns themselves cannot be expressions, we CAN accept arbitrary expressions AFTER comparison operators (`>`, `>=`, `<`, `<=`, and in the future `!=`, `==`). For example: `age: > compute_min_age()` would be valid
+7. **Special operator handling**: `=~` is treated specially and currently only accepts regex literals, not arbitrary expressions (though this could be improved later)
 
 ### Development Best Practices
 1. **Incremental feature development**: Build features progressively (Option → Result → custom enums → tuples)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,42 @@ dependencies = [
  "quote",
  "regex",
  "syn",
+ "trybuild",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "memchr"
@@ -75,6 +110,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,7 +168,164 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
+name = "trybuild"
+version = "1.0.110"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e257d7246e7a9fd015fb0b28b330a8d4142151a33f03e6a497754f4b1f6a8e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ quote = "1.0"
 proc-macro2 = "1.0"
 regex = { version = "1.10", optional = true }
 
+[dev-dependencies]
+trybuild = "1.0"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ assert_struct!(response, Response {
 ### Advanced Matchers
 
 - **Comparison operators** - Use `<`, `<=`, `>`, `>=` for numeric field assertions
+- **Equality operators** - Use `==` and `!=` for explicit equality/inequality checks
 - **Regex patterns** - Match string fields with regular expressions using `=~ r"pattern"`
 - **Advanced enum patterns** - Use comparison operators and regex inside `Some()` and other variants
 
@@ -356,9 +357,9 @@ assert_struct!(error_account, Account {
 });
 ```
 
-### Comparison Operators
+### Comparison and Equality Operators
 
-Perfect for range checks and threshold validations:
+Perfect for range checks, threshold validations, and explicit equality tests:
 
 ```rust
 #[derive(Debug)]
@@ -366,18 +367,28 @@ struct Metrics {
     cpu_usage: f64,
     memory_mb: u32,
     response_time_ms: u32,
+    status: String,
 }
 
 let metrics = Metrics {
     cpu_usage: 75.5,
     memory_mb: 1024,
     response_time_ms: 150,
+    status: "ok".to_string(),
 };
 
 assert_struct!(metrics, Metrics {
-    cpu_usage: < 80.0,        // Less than 80%
-    memory_mb: <= 2048,        // At most 2GB
-    response_time_ms: < 200,   // Under 200ms
+    cpu_usage: < 80.0,         // Less than 80%
+    memory_mb: <= 2048,         // At most 2GB
+    response_time_ms: < 200,    // Under 200ms
+    status: == "ok",            // Exact equality
+});
+
+// Inequality checks
+assert_struct!(metrics, Metrics {
+    status: != "error",         // Not equal to "error"
+    memory_mb: != 0,            // Not zero
+    ..
 });
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,37 @@
+# TODO
+
+## Next Features
+
+### 1. Equality operators (`==`, `!=`) ✅
+- [x] Add `==` operator for explicit equality checks
+  - Example: `age: == 30`
+  - Example: `name: == "Alice"`
+- [x] Add `!=` operator for inequality checks
+  - Example: `status: != "error"`
+  - Example: `count: != 0`
+- [x] Support in all contexts (fields, tuples, enum variants)
+- [x] Add comprehensive tests
+- [x] Update documentation
+
+### 2. Arbitrary expressions after operators
+- [ ] Allow complex expressions after comparison operators
+  - Example: `age: > compute_min_age()`
+  - Example: `score: < get_threshold() + 10`
+  - Example: `value: >= some_struct.field`
+- [ ] Ensure proper parsing of function calls, field access, method calls
+- [ ] Test with various expression types
+- [ ] Update documentation with examples
+
+### 3. Improved regex operator
+- [ ] Consider allowing variables containing regex patterns
+- [ ] Consider function calls returning regex patterns
+- [ ] Need to carefully design compile-time vs runtime behavior
+- [ ] Maintain backward compatibility with current `=~ r"pattern"` syntax
+- [ ] Document any limitations or trade-offs
+
+## Architecture Notes
+
+These features fit within the current design because:
+- They all follow the "operator followed by expression" pattern
+- They don't introduce parsing ambiguities
+- They maintain the principle of "no arbitrary expressions in pattern positions"

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -118,11 +118,13 @@ fn generate_assertions(expected: &Expected) -> TokenStream {
                 ..
             } => {
                 // Comparison: generate appropriate comparison assertion
-                let op_str = match op {
-                    ComparisonOp::Less => "<",
-                    ComparisonOp::LessEqual => "<=",
-                    ComparisonOp::Greater => ">",
-                    ComparisonOp::GreaterEqual => ">=",
+                let (op_str, error_msg) = match op {
+                    ComparisonOp::Less => ("<", "comparison"),
+                    ComparisonOp::LessEqual => ("<=", "comparison"),
+                    ComparisonOp::Greater => (">", "comparison"),
+                    ComparisonOp::GreaterEqual => (">=", "comparison"),
+                    ComparisonOp::Equal => ("==", "equality"),
+                    ComparisonOp::NotEqual => ("!=", "inequality"),
                 };
 
                 let comparison = match op {
@@ -130,13 +132,16 @@ fn generate_assertions(expected: &Expected) -> TokenStream {
                     ComparisonOp::LessEqual => quote! { #field_name <= &#value },
                     ComparisonOp::Greater => quote! { #field_name > &#value },
                     ComparisonOp::GreaterEqual => quote! { #field_name >= &#value },
+                    ComparisonOp::Equal => quote! { #field_name == &#value },
+                    ComparisonOp::NotEqual => quote! { #field_name != &#value },
                 };
 
                 assertions.push(quote! {
                     if !(#comparison) {
                         panic!(
-                            "Field `{}` failed comparison: {:?} {} {}",
+                            "Field `{}` failed {}: {:?} {} {:?}",
                             stringify!(#field_name),
+                            #error_msg,
                             #field_name,
                             #op_str,
                             &#value
@@ -301,11 +306,13 @@ fn generate_pattern_element_assertion(
             }
         }
         PatternElement::Comparison(op, value) => {
-            let op_str = match op {
-                ComparisonOp::Less => "<",
-                ComparisonOp::LessEqual => "<=",
-                ComparisonOp::Greater => ">",
-                ComparisonOp::GreaterEqual => ">=",
+            let (op_str, error_msg) = match op {
+                ComparisonOp::Less => ("<", "comparison"),
+                ComparisonOp::LessEqual => ("<=", "comparison"),
+                ComparisonOp::Greater => (">", "comparison"),
+                ComparisonOp::GreaterEqual => (">=", "comparison"),
+                ComparisonOp::Equal => ("==", "equality"),
+                ComparisonOp::NotEqual => ("!=", "inequality"),
             };
 
             let comparison = match op {
@@ -313,12 +320,15 @@ fn generate_pattern_element_assertion(
                 ComparisonOp::LessEqual => quote! { #elem_name <= &#value },
                 ComparisonOp::Greater => quote! { #elem_name > &#value },
                 ComparisonOp::GreaterEqual => quote! { #elem_name >= &#value },
+                ComparisonOp::Equal => quote! { #elem_name == &#value },
+                ComparisonOp::NotEqual => quote! { #elem_name != &#value },
             };
 
             quote! {
                 if !(#comparison) {
                     panic!(
-                        "Element failed comparison: {:?} {} {}",
+                        "Element failed {}: {:?} {} {:?}",
+                        #error_msg,
                         #elem_name,
                         #op_str,
                         &#value
@@ -545,11 +555,13 @@ fn generate_option_assertion(field_name: &syn::Ident, element: &PatternElement) 
             }
         }
         PatternElement::Comparison(op, value) => {
-            let op_str = match op {
-                ComparisonOp::Less => "<",
-                ComparisonOp::LessEqual => "<=",
-                ComparisonOp::Greater => ">",
-                ComparisonOp::GreaterEqual => ">=",
+            let (op_str, error_msg) = match op {
+                ComparisonOp::Less => ("<", "comparison"),
+                ComparisonOp::LessEqual => ("<=", "comparison"),
+                ComparisonOp::Greater => (">", "comparison"),
+                ComparisonOp::GreaterEqual => (">=", "comparison"),
+                ComparisonOp::Equal => ("==", "equality"),
+                ComparisonOp::NotEqual => ("!=", "inequality"),
             };
 
             let comparison = match op {
@@ -557,6 +569,8 @@ fn generate_option_assertion(field_name: &syn::Ident, element: &PatternElement) 
                 ComparisonOp::LessEqual => quote! { inner <= &#value },
                 ComparisonOp::Greater => quote! { inner > &#value },
                 ComparisonOp::GreaterEqual => quote! { inner >= &#value },
+                ComparisonOp::Equal => quote! { inner == &#value },
+                ComparisonOp::NotEqual => quote! { inner != &#value },
             };
 
             quote! {
@@ -564,8 +578,9 @@ fn generate_option_assertion(field_name: &syn::Ident, element: &PatternElement) 
                     Some(inner) => {
                         if !(#comparison) {
                             panic!(
-                                "Field `{}` failed comparison: Some({:?}) {} {}",
+                                "Field `{}` failed {}: Some({:?}) {} {:?}",
                                 stringify!(#field_name),
+                                #error_msg,
                                 inner,
                                 #op_str,
                                 &#value
@@ -694,6 +709,8 @@ fn generate_struct_field_assignments(nested: &Expected) -> Vec<TokenStream> {
                                     ComparisonOp::LessEqual => quote! { <= },
                                     ComparisonOp::Greater => quote! { > },
                                     ComparisonOp::GreaterEqual => quote! { >= },
+                                    ComparisonOp::Equal => quote! { == },
+                                    ComparisonOp::NotEqual => quote! { != },
                                 };
                                 quote! { #op_tokens #value }
                             }
@@ -738,6 +755,8 @@ fn generate_struct_field_assignments(nested: &Expected) -> Vec<TokenStream> {
                                     ComparisonOp::LessEqual => quote! { <= },
                                     ComparisonOp::Greater => quote! { > },
                                     ComparisonOp::GreaterEqual => quote! { >= },
+                                    ComparisonOp::Equal => quote! { == },
+                                    ComparisonOp::NotEqual => quote! { != },
                                 };
                                 quote! { #op_tokens #value }
                             }
@@ -796,6 +815,8 @@ fn generate_struct_field_assignments(nested: &Expected) -> Vec<TokenStream> {
                     ComparisonOp::LessEqual => quote! { <= },
                     ComparisonOp::Greater => quote! { > },
                     ComparisonOp::GreaterEqual => quote! { >= },
+                    ComparisonOp::Equal => quote! { == },
+                    ComparisonOp::NotEqual => quote! { != },
                 };
                 field_assignments.push(quote! {
                     #field_name: #op_tokens #value
@@ -819,6 +840,8 @@ fn generate_pattern_element_values(elements: &[PatternElement]) -> Vec<TokenStre
                     ComparisonOp::LessEqual => quote! { <= },
                     ComparisonOp::Greater => quote! { > },
                     ComparisonOp::GreaterEqual => quote! { >= },
+                    ComparisonOp::Equal => quote! { == },
+                    ComparisonOp::NotEqual => quote! { != },
                 };
                 quote! { #op_tokens #value }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@
 //! ## Advanced Matchers
 //!
 //! - **Comparison Operators** - Use `<`, `<=`, `>`, `>=` for numeric field assertions
+//! - **Equality Operators** - Use `==` and `!=` for explicit equality/inequality checks
 //! - **Regex Patterns** - Match string fields with regular expressions using `=~ r"pattern"`
 //! - **Advanced Enum Patterns** - Use comparison operators and regex inside `Some()` and other variants
 //!
@@ -523,6 +524,8 @@ enum ComparisonOp {
     LessEqual,
     Greater,
     GreaterEqual,
+    Equal,
+    NotEqual,
 }
 
 /// Asserts that a struct matches an expected pattern.
@@ -546,6 +549,7 @@ enum ComparisonOp {
 /// | Matcher | Description | Example |
 /// |---------|-------------|---------|
 /// | Exact value | Direct equality comparison | `name: "Alice"` |
+/// | Equality | Explicit equality/inequality | `age: == 30`, `status: != "error"` |
 /// | Comparison | Numeric comparisons | `age: >= 18` |
 /// | Regex | Pattern matching (requires `regex` feature) | `email: =~ r"@.*\.com$"` |
 /// | Option | Match `Some` and `None` variants | `age: Some(30)`, `bio: None` |
@@ -590,16 +594,22 @@ enum ComparisonOp {
 /// });
 /// ```
 ///
-/// ## Comparison Operators
+/// ## Comparison and Equality Operators
 ///
 /// ```
 /// # use assert_struct::assert_struct;
-/// # #[derive(Debug)]
-/// # struct Score { value: i32, bonus: f64 }
-/// # let score = Score { value: 95, bonus: 1.5 };
+/// # #[derive(Debug, PartialEq)]
+/// # struct Score { value: i32, bonus: f64, grade: String }
+/// # let score = Score { value: 95, bonus: 1.5, grade: "A".to_string() };
 /// assert_struct!(score, Score {
-///     value: > 90,
-///     bonus: >= 1.0,
+///     value: > 90,        // Greater than
+///     bonus: >= 1.0,      // Greater or equal
+///     grade: == "A",      // Explicit equality
+/// });
+///
+/// assert_struct!(score, Score {
+///     grade: != "F",      // Not equal
+///     ..
 /// });
 /// ```
 ///

--- a/tests/compile_fail/equality_with_rest_pattern.rs
+++ b/tests/compile_fail/equality_with_rest_pattern.rs
@@ -1,0 +1,24 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug, PartialEq)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug)]
+struct Shape {
+    origin: Point,
+}
+
+fn main() {
+    let shape = Shape {
+        origin: Point { x: 0, y: 0 },
+    };
+
+    // This should NOT compile - .. is not valid in expressions
+    // The `..` rest pattern is only valid in pattern position, not in expressions
+    assert_struct!(shape, Shape {
+        origin: == Point { .. },
+    });
+}

--- a/tests/compile_fail/equality_with_rest_pattern.stderr
+++ b/tests/compile_fail/equality_with_rest_pattern.stderr
@@ -1,0 +1,10 @@
+error[E0797]: base expression required after `..`
+  --> tests/compile_fail/equality_with_rest_pattern.rs:22:30
+   |
+22 |         origin: == Point { .. },
+   |                              ^
+   |
+help: add a base expression here
+   |
+22 |         origin: == Point { ../* expr */ },
+   |                              ++++++++++

--- a/tests/compile_fail/field_does_not_exist.rs
+++ b/tests/compile_fail/field_does_not_exist.rs
@@ -1,0 +1,21 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct User {
+    name: String,
+    age: u32,
+}
+
+fn main() {
+    let user = User {
+        name: "Alice".to_string(),
+        age: 30,
+    };
+
+    // This should NOT compile - field 'email' does not exist
+    assert_struct!(user, User {
+        name: "Alice",
+        age: 30,
+        email: "alice@example.com",
+    });
+}

--- a/tests/compile_fail/field_does_not_exist.stderr
+++ b/tests/compile_fail/field_does_not_exist.stderr
@@ -1,0 +1,5 @@
+error[E0026]: struct `User` does not have a field named `email`
+  --> tests/compile_fail/field_does_not_exist.rs:19:9
+   |
+19 |         email: "alice@example.com",
+   |         ^^^^^ struct `User` does not have this field

--- a/tests/compile_fail/type_mismatch.rs
+++ b/tests/compile_fail/type_mismatch.rs
@@ -1,0 +1,20 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct User {
+    name: String,
+    age: u32,
+}
+
+fn main() {
+    let user = User {
+        name: "Alice".to_string(),
+        age: 30,
+    };
+
+    // This should NOT compile - age is u32, not String
+    assert_struct!(user, User {
+        name: "Alice",
+        age: "thirty",
+    });
+}

--- a/tests/compile_fail/type_mismatch.stderr
+++ b/tests/compile_fail/type_mismatch.stderr
@@ -1,0 +1,14 @@
+error[E0277]: can't compare `u32` with `&str`
+  --> tests/compile_fail/type_mismatch.rs:16:5
+   |
+16 | /     assert_struct!(user, User {
+17 | |         name: "Alice",
+18 | |         age: "thirty",
+19 | |     });
+   | |______^ no implementation for `u32 == &str`
+   |
+   = help: the trait `PartialEq<&str>` is not implemented for `u32`
+           but trait `PartialEq<u32>` is implemented for it
+   = help: for that trait implementation, expected `u32`, found `&str`
+   = note: required for `&u32` to implement `PartialEq<&&str>`
+   = note: this error originates in the macro `assert_eq` which comes from the expansion of the macro `assert_struct` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/equality.rs
+++ b/tests/equality.rs
@@ -1,0 +1,133 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct User {
+    name: String,
+    age: u32,
+    score: f64,
+    active: bool,
+}
+
+#[test]
+fn test_equality_operator() {
+    let user = User {
+        name: "Alice".to_string(),
+        age: 30,
+        score: 95.5,
+        active: true,
+    };
+
+    assert_struct!(user, User {
+        name: == "Alice",
+        age: == 30,
+        score: == 95.5,
+        active: == true,
+    });
+}
+
+#[test]
+fn test_inequality_operator() {
+    let user = User {
+        name: "Alice".to_string(),
+        age: 30,
+        score: 95.5,
+        active: true,
+    };
+
+    assert_struct!(user, User {
+        name: != "Bob",
+        age: != 25,
+        score: != 0.0,
+        active: != false,
+    });
+}
+
+#[test]
+fn test_mixed_operators() {
+    let user = User {
+        name: "Alice".to_string(),
+        age: 30,
+        score: 95.5,
+        active: true,
+    };
+
+    assert_struct!(user, User {
+        name: == "Alice",
+        age: >= 18,
+        score: > 90.0,
+        active: != false,
+    });
+}
+
+// Test with Option
+#[derive(Debug)]
+struct Profile {
+    bio: Option<String>,
+    age: Option<u32>,
+}
+
+#[test]
+fn test_equality_in_option() {
+    let profile = Profile {
+        bio: Some("Developer".to_string()),
+        age: Some(30),
+    };
+
+    assert_struct!(profile, Profile {
+        bio: Some(== "Developer"),
+        age: Some(!= 0),
+    });
+}
+
+// Test with tuples
+#[derive(Debug)]
+struct Data {
+    pair: (i32, String),
+    triple: (bool, f64, u32),
+}
+
+#[test]
+fn test_equality_in_tuples() {
+    let data = Data {
+        pair: (42, "test".to_string()),
+        triple: (true, 3.5, 100),
+    };
+
+    assert_struct!(data, Data {
+        pair: (== 42, != "other"),
+        triple: (!= false, == 3.5, != 0),
+    });
+}
+
+// Test failure cases
+#[test]
+#[should_panic(expected = "Field `name` failed equality")]
+fn test_equality_failure() {
+    let user = User {
+        name: "Alice".to_string(),
+        age: 30,
+        score: 95.5,
+        active: true,
+    };
+
+    assert_struct!(user, User {
+        name: == "Bob",  // Should fail
+        ..
+    });
+}
+
+#[test]
+#[should_panic(expected = "Field `age` failed inequality")]
+fn test_inequality_failure() {
+    let user = User {
+        name: "Alice".to_string(),
+        age: 30,
+        score: 95.5,
+        active: true,
+    };
+
+    assert_struct!(user, User {
+        age: != 30,  // Should fail
+        ..
+    });
+}

--- a/tests/equality_compilation_test.rs
+++ b/tests/equality_compilation_test.rs
@@ -1,0 +1,77 @@
+// This file tests that certain patterns correctly fail to compile
+
+use assert_struct::assert_struct;
+
+#[derive(Debug, PartialEq)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug)]
+struct Shape {
+    origin: Point,
+}
+
+#[test]
+fn test_equality_requires_complete_expression() {
+    let shape = Shape {
+        origin: Point { x: 0, y: 0 },
+    };
+
+    // This SHOULD work - complete struct expression
+    assert_struct!(shape, Shape {
+        origin: == Point { x: 0, y: 0 },  // Complete expression
+    });
+
+    // The following would NOT compile if uncommented:
+    // assert_struct!(shape, Shape {
+    //     origin: == Point { .. },  // ERROR: `..` is not valid in expressions
+    // });
+
+    // But this DOES work - pattern matching without ==
+    assert_struct!(
+        shape,
+        Shape {
+            origin: Point { x: 0, .. }, // Pattern with partial matching
+        }
+    );
+}
+
+// This test demonstrates the key difference
+#[test]
+fn test_pattern_vs_expression_distinction() {
+    #[derive(Debug, PartialEq)]
+    struct Complex {
+        a: i32,
+        b: i32,
+        c: i32,
+    }
+
+    #[derive(Debug)]
+    struct Container {
+        data: Complex,
+    }
+
+    let container = Container {
+        data: Complex { a: 1, b: 2, c: 3 },
+    };
+
+    // Pattern matching - can use `..` to ignore fields
+    assert_struct!(
+        container,
+        Container {
+            data: Complex { a: 1, .. }, // Only check `a`, ignore b and c
+        }
+    );
+
+    // Equality check - must specify complete value
+    assert_struct!(container, Container {
+        data: == Complex { a: 1, b: 2, c: 3 },  // Must specify all fields
+    });
+
+    // This would NOT compile:
+    // assert_struct!(container, Container {
+    //     data: == Complex { a: 1, .. },  // ERROR: Can't use .. in expression
+    // });
+}

--- a/tests/equality_struct.rs
+++ b/tests/equality_struct.rs
@@ -1,0 +1,185 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug, PartialEq)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug)]
+struct Shape {
+    origin: Point,
+    center: Point,
+}
+
+#[test]
+fn test_equality_with_struct_literal() {
+    let shape = Shape {
+        origin: Point { x: 0, y: 0 },
+        center: Point { x: 10, y: 20 },
+    };
+
+    // Test that we can use == with struct expressions
+    assert_struct!(shape, Shape {
+        origin: == Point { x: 0, y: 0 },
+        center: == Point { x: 10, y: 20 },
+    });
+}
+
+#[test]
+fn test_inequality_with_struct_literal() {
+    let shape = Shape {
+        origin: Point { x: 0, y: 0 },
+        center: Point { x: 10, y: 20 },
+    };
+
+    // Test that we can use != with struct expressions
+    assert_struct!(shape, Shape {
+        origin: != Point { x: 5, y: 5 },
+        center: != Point { x: 0, y: 0 },
+    });
+}
+
+#[test]
+fn test_mixed_patterns_and_equality() {
+    let shape = Shape {
+        origin: Point { x: 0, y: 0 },
+        center: Point { x: 10, y: 20 },
+    };
+
+    // Mix direct patterns with equality operators
+    assert_struct!(shape, Shape {
+        origin: Point { x: 0, y: 0 },  // Direct pattern matching
+        center: == Point { x: 10, y: 20 },  // Equality operator with expression
+    });
+}
+
+// Test with Option containing structs
+#[derive(Debug)]
+struct Container {
+    point: Option<Point>,
+}
+
+#[test]
+fn test_equality_in_option_with_struct() {
+    let container = Container {
+        point: Some(Point { x: 5, y: 10 }),
+    };
+
+    assert_struct!(container, Container {
+        point: Some(== Point { x: 5, y: 10 }),
+    });
+}
+
+// Test with nested struct equality
+#[derive(Debug, PartialEq)]
+struct Size {
+    width: u32,
+    height: u32,
+}
+
+#[derive(Debug, PartialEq)]
+struct Window {
+    title: String,
+    size: Size,
+}
+
+#[derive(Debug)]
+struct App {
+    main_window: Window,
+}
+
+#[test]
+fn test_nested_struct_equality() {
+    let app = App {
+        main_window: Window {
+            title: "Main".to_string(),
+            size: Size {
+                width: 800,
+                height: 600,
+            },
+        },
+    };
+
+    assert_struct!(app, App {
+        main_window: == Window {
+            title: "Main".to_string(),
+            size: Size { width: 800, height: 600 },
+        },
+    });
+}
+
+// Test failure cases
+#[test]
+#[should_panic(expected = "Field `origin` failed equality")]
+fn test_struct_equality_failure() {
+    let shape = Shape {
+        origin: Point { x: 0, y: 0 },
+        center: Point { x: 10, y: 20 },
+    };
+
+    assert_struct!(shape, Shape {
+        origin: == Point { x: 1, y: 1 },  // Should fail
+        ..
+    });
+}
+
+#[test]
+#[should_panic(expected = "Field `center` failed inequality")]
+fn test_struct_inequality_failure() {
+    let shape = Shape {
+        origin: Point { x: 0, y: 0 },
+        center: Point { x: 10, y: 20 },
+    };
+
+    assert_struct!(shape, Shape {
+        center: != Point { x: 10, y: 20 },  // Should fail - they are equal
+        ..
+    });
+}
+
+// Test with more complex expressions
+#[test]
+fn test_equality_with_method_call() {
+    let shape = Shape {
+        origin: Point { x: 0, y: 0 },
+        center: Point { x: 10, y: 20 },
+    };
+
+    let expected_origin = Point { x: 0, y: 0 };
+
+    assert_struct!(shape, Shape {
+        origin: == expected_origin,  // Use a variable
+        center: == Point { x: 10, y: 20 },
+    });
+}
+
+// Test that direct pattern matching still works and is distinct from equality
+#[test]
+fn test_pattern_vs_equality_distinction() {
+    #[derive(Debug)]
+    struct Data {
+        // This Point doesn't implement PartialEq
+        location: Location,
+        // This Point does implement PartialEq
+        point: Point,
+    }
+
+    #[derive(Debug)]
+    struct Location {
+        x: i32,
+        y: i32,
+    }
+
+    let data = Data {
+        location: Location { x: 5, y: 10 },
+        point: Point { x: 5, y: 10 },
+    };
+
+    assert_struct!(data, Data {
+        // Pattern matching - doesn't need PartialEq
+        location: Location { x: 5, y: 10 },
+        // Equality check - needs PartialEq
+        point: == Point { x: 5, y: 10 },
+    });
+}

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -1,0 +1,5 @@
+#[test]
+fn compile_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}


### PR DESCRIPTION
## Summary

This PR introduces `==` and `\!=` operators to enable explicit equality and inequality comparisons in assert_struct patterns. These operators complement the existing comparison operators (`<`, `<=`, `>`, `>=`) and provide users with more expressive assertion capabilities.

## Key Changes

### New Operators
- **`==`** - Explicit equality check
- **`\!=`** - Explicit inequality check

### Example Usage

```rust
assert_struct\!(user, User {
    name: == "Alice",      // Explicit equality
    age: \!= 0,             // Not equal to zero
    score: > 90,           // Existing comparison operator
});

// Works with struct literals
assert_struct\!(shape, Shape {
    origin: == Point { x: 0, y: 0 },  // Compare entire structs
});

// Works in Option and tuples
assert_struct\!(data, Data {
    value: Some(== 42),
    pair: (== "test", \!= 0),
});
```

## Important Design Note

This implementation maintains the architectural distinction between **patterns** and **expressions**:

- **Pattern syntax** (without operators): `Point { x: 0, .. }` - Allows partial matching with `..`
- **Expression syntax** (with operators): `== Point { x: 0, y: 0 }` - Requires complete, valid expressions

Attempting to use `== Point { .. }` correctly fails to compile with error E0797: "base expression required after `..`"

## Testing

- Comprehensive unit tests for equality/inequality operators
- Tests with struct literals, Option types, and tuples
- Compile-fail tests using trybuild to verify invalid syntax is rejected
- All existing tests continue to pass

## Documentation

- Updated README with equality operator examples
- Updated crate documentation and matcher table
- Added code examples in macro documentation

## Checklist

- [x] Tests pass locally
- [x] Documentation updated
- [x] Clippy warnings addressed
- [x] Works with `--no-default-features`