### PR TITLE
Generalize macro to accept any pattern at root

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,798 +1,491 @@
-use crate::{AssertStruct, ComparisonOp, Expected, FieldAssertion, PatternElement};
+use crate::{AssertStruct, ComparisonOp, FieldAssertion, Pattern};
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::Expr;
+use syn::{Expr, Token, punctuated::Punctuated};
 
 pub fn expand(assert: &AssertStruct) -> TokenStream {
     let value = &assert.value;
-    let type_name = &assert.type_name;
+    let pattern = &assert.pattern;
 
-    // Collect all field names for destructuring
-    let field_names: Vec<_> = assert
-        .expected
-        .fields
-        .iter()
-        .map(|f| match f {
-            FieldAssertion::Simple { field_name, .. } => field_name.clone(),
-            FieldAssertion::StructPattern { field_name, .. } => field_name.clone(),
-            FieldAssertion::TuplePattern { field_name, .. } => field_name.clone(),
-            FieldAssertion::UnitPattern { field_name, .. } => field_name.clone(),
-            #[cfg(feature = "regex")]
-            FieldAssertion::Regex { field_name, .. } => field_name.clone(),
-            FieldAssertion::Comparison { field_name, .. } => field_name.clone(),
-            FieldAssertion::Range { field_name, .. } => field_name.clone(),
-            FieldAssertion::SlicePattern { field_name, .. } => field_name.clone(),
-        })
-        .collect();
+    // Generate the assertion for the root pattern
+    let assertion = generate_pattern_assertion(&quote! { #value }, pattern, false);
 
-    // Handle partial matching with ..
-    let rest_pattern = if assert.expected.rest {
+    quote! {
+        {
+            #assertion
+        }
+    }
+}
+
+// Generate assertion code for any pattern
+// is_ref indicates whether value_expr is already a reference
+fn generate_pattern_assertion(
+    value_expr: &TokenStream,
+    pattern: &Pattern,
+    is_ref: bool,
+) -> TokenStream {
+    match pattern {
+        Pattern::Simple(expected) => {
+            // Simple value comparison
+            let transformed = transform_expected_value(expected);
+            if is_ref {
+                quote! {
+                    assert_eq!(#value_expr, &#transformed);
+                }
+            } else {
+                quote! {
+                    assert_eq!(&#value_expr, &#transformed);
+                }
+            }
+        }
+        Pattern::Struct { path, fields, rest } => {
+            // Check if this is an enum variant (path has multiple segments or starts with uppercase)
+            let is_enum_variant = if path.segments.len() > 1 {
+                true
+            } else if let Some(segment) = path.segments.first() {
+                segment
+                    .ident
+                    .to_string()
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_uppercase())
+            } else {
+                false
+            };
+
+            if is_enum_variant {
+                // Enum struct variant - generate match expression
+                generate_enum_struct_assertion(value_expr, path, fields, *rest, is_ref)
+            } else {
+                // Regular struct - use let destructuring
+                let field_names: Vec<_> = fields.iter().map(|f| &f.field_name).collect();
+
+                let rest_pattern = if *rest {
+                    quote! { , .. }
+                } else {
+                    quote! {}
+                };
+
+                let field_assertions: Vec<_> = fields
+                    .iter()
+                    .map(|f| {
+                        let field_name = &f.field_name;
+                        let field_pattern = &f.pattern;
+                        // Fields from destructuring are references
+                        generate_pattern_assertion(&quote! { #field_name }, field_pattern, true)
+                    })
+                    .collect();
+
+                quote! {
+                    let #path { #(#field_names),* #rest_pattern } = &#value_expr;
+                    #(#field_assertions)*
+                }
+            }
+        }
+        Pattern::Tuple { path, elements } => {
+            // Handle both plain tuples and enum variants
+            if let Some(variant_path) = path {
+                // Enum variant (Some(...), None, Ok(...), etc.)
+                if elements.is_empty() {
+                    // Unit variant like None
+                    generate_unit_variant_assertion(value_expr, variant_path, is_ref)
+                } else {
+                    // Tuple variant with data
+                    generate_enum_tuple_assertion(value_expr, variant_path, elements, is_ref)
+                }
+            } else {
+                // Plain tuple
+                generate_plain_tuple_assertion(value_expr, elements, is_ref)
+            }
+        }
+        Pattern::Slice(elements) => {
+            // Slice pattern using Rust's native slice matching
+            generate_slice_assertion(value_expr, elements, is_ref)
+        }
+        Pattern::Comparison(op, value) => {
+            // Comparison operators
+            generate_comparison_assertion(value_expr, op, value, is_ref)
+        }
+        Pattern::Range(range) => {
+            // Range pattern
+            if is_ref {
+                quote! {
+                    match #value_expr {
+                        #range => {},
+                        _ => panic!(
+                            "Value not in range: {:?} not matching pattern",
+                            #value_expr
+                        ),
+                    }
+                }
+            } else {
+                quote! {
+                    match &#value_expr {
+                        #range => {},
+                        _ => panic!(
+                            "Value not in range: {:?} not matching pattern",
+                            &#value_expr
+                        ),
+                    }
+                }
+            }
+        }
+        #[cfg(feature = "regex")]
+        Pattern::Regex(pattern_str) => {
+            // Regex pattern
+            if is_ref {
+                quote! {
+                    {
+                        let re = ::regex::Regex::new(#pattern_str)
+                            .expect(concat!("Invalid regex pattern: ", #pattern_str));
+                        if !re.is_match(#value_expr) {
+                            panic!(
+                                "Value does not match regex pattern `{}`\n  value: {:?}",
+                                #pattern_str,
+                                #value_expr
+                            );
+                        }
+                    }
+                }
+            } else {
+                quote! {
+                    {
+                        let re = ::regex::Regex::new(#pattern_str)
+                            .expect(concat!("Invalid regex pattern: ", #pattern_str));
+                        if !re.is_match(&#value_expr) {
+                            panic!(
+                                "Value does not match regex pattern `{}`\n  value: {:?}",
+                                #pattern_str,
+                                &#value_expr
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        Pattern::Rest => {
+            // Rest patterns don't generate assertions themselves
+            quote! {}
+        }
+    }
+}
+
+// Generate assertion for unit variants like None
+fn generate_unit_variant_assertion(
+    value_expr: &TokenStream,
+    path: &syn::Path,
+    is_ref: bool,
+) -> TokenStream {
+    // Special handling for None
+    if is_option_none_path(path) {
+        if is_ref {
+            quote! {
+                match #value_expr {
+                    None => {},
+                    Some(_) => panic!("Expected None, got Some"),
+                }
+            }
+        } else {
+            quote! {
+                match &#value_expr {
+                    None => {},
+                    Some(_) => panic!("Expected None, got Some"),
+                }
+            }
+        }
+    } else {
+        // General unit variant
+        if is_ref {
+            quote! {
+                match #value_expr {
+                    #path => {},
+                    _ => panic!(
+                        "Expected {}, got {:?}",
+                        stringify!(#path),
+                        #value_expr
+                    ),
+                }
+            }
+        } else {
+            quote! {
+                match &#value_expr {
+                    #path => {},
+                    _ => panic!(
+                        "Expected {}, got {:?}",
+                        stringify!(#path),
+                        &#value_expr
+                    ),
+                }
+            }
+        }
+    }
+}
+
+// Generate assertion for enum struct variants
+fn generate_enum_struct_assertion(
+    value_expr: &TokenStream,
+    path: &syn::Path,
+    fields: &Punctuated<FieldAssertion, Token![,]>,
+    rest: bool,
+    is_ref: bool,
+) -> TokenStream {
+    let field_names: Vec<_> = fields.iter().map(|f| &f.field_name).collect();
+
+    let rest_pattern = if rest {
         quote! { , .. }
     } else {
         quote! {}
     };
 
-    // Generate the destructuring pattern with references to avoid moves
-    // In Rust 2024 edition, we use & on the value instead of ref in the pattern
-    let destructure = quote! {
-        let #type_name { #(#field_names),* #rest_pattern } = &#value;
+    let field_assertions: Vec<_> = fields
+        .iter()
+        .map(|f| {
+            let field_name = &f.field_name;
+            let field_pattern = &f.pattern;
+            // Fields from destructuring are references
+            generate_pattern_assertion(&quote! { #field_name }, field_pattern, true)
+        })
+        .collect();
+
+    if is_ref {
+        quote! {
+            match #value_expr {
+                #path { #(#field_names),* #rest_pattern } => {
+                    #(#field_assertions)*
+                },
+                _ => panic!(
+                    "Expected {}, got {:?}",
+                    stringify!(#path),
+                    #value_expr
+                ),
+            }
+        }
+    } else {
+        quote! {
+            match &#value_expr {
+                #path { #(#field_names),* #rest_pattern } => {
+                    #(#field_assertions)*
+                },
+                _ => panic!(
+                    "Expected {}, got {:?}",
+                    stringify!(#path),
+                    &#value_expr
+                ),
+            }
+        }
+    }
+}
+
+// Generate assertion for enum tuple variants
+fn generate_enum_tuple_assertion(
+    value_expr: &TokenStream,
+    path: &syn::Path,
+    elements: &[Pattern],
+    is_ref: bool,
+) -> TokenStream {
+    // Special handling for Some
+    if is_option_some_path(path) && elements.len() == 1 {
+        let inner_assertion = generate_pattern_assertion(
+            &quote! { inner },
+            &elements[0],
+            true, // inner is a reference from the match
+        );
+        if is_ref {
+            return quote! {
+                match #value_expr {
+                    Some(inner) => {
+                        #inner_assertion
+                    },
+                    None => panic!("Expected Some(...), got None"),
+                }
+            };
+        } else {
+            return quote! {
+                match &#value_expr {
+                    Some(inner) => {
+                        #inner_assertion
+                    },
+                    None => panic!("Expected Some(...), got None"),
+                }
+            };
+        }
+    }
+
+    // General enum tuple variant
+    let element_names: Vec<_> = (0..elements.len())
+        .map(|i| quote::format_ident!("__elem_{}", i))
+        .collect();
+
+    let element_assertions: Vec<_> = element_names
+        .iter()
+        .zip(elements)
+        .map(|(name, pattern)| generate_pattern_assertion(&quote! { #name }, pattern, true))
+        .collect();
+
+    if is_ref {
+        quote! {
+            match #value_expr {
+                #path(#(#element_names),*) => {
+                    #(#element_assertions)*
+                },
+                _ => panic!(
+                    "Expected {}, got {:?}",
+                    stringify!(#path),
+                    #value_expr
+                ),
+            }
+        }
+    } else {
+        quote! {
+            match &#value_expr {
+                #path(#(#element_names),*) => {
+                    #(#element_assertions)*
+                },
+                _ => panic!(
+                    "Expected {}, got {:?}",
+                    stringify!(#path),
+                    &#value_expr
+                ),
+            }
+        }
+    }
+}
+
+// Generate assertion for plain tuples
+fn generate_plain_tuple_assertion(
+    value_expr: &TokenStream,
+    elements: &[Pattern],
+    is_ref: bool,
+) -> TokenStream {
+    let element_names: Vec<_> = (0..elements.len())
+        .map(|i| quote::format_ident!("__tuple_elem_{}", i))
+        .collect();
+
+    let destructure = if is_ref {
+        quote! {
+            let (#(#element_names),*) = #value_expr;
+        }
+    } else {
+        quote! {
+            let (#(#element_names),*) = &#value_expr;
+        }
     };
 
-    // Generate assertions for each field
-    let assertions = generate_assertions(&assert.expected);
+    let element_assertions: Vec<_> = element_names
+        .iter()
+        .zip(elements)
+        .map(|(name, pattern)| generate_pattern_assertion(&quote! { #name }, pattern, true))
+        .collect();
 
     quote! {
         {
             #destructure
-            #assertions
+            #(#element_assertions)*
         }
     }
 }
 
-fn generate_assertions(expected: &Expected) -> TokenStream {
-    let mut assertions = Vec::new();
+// Generate assertion for slice patterns
+fn generate_slice_assertion(
+    value_expr: &TokenStream,
+    elements: &[Pattern],
+    _is_ref: bool,
+) -> TokenStream {
+    let mut pattern_parts = Vec::new();
+    let mut bindings_and_assertions = Vec::new();
 
-    for field in &expected.fields {
-        match field {
-            FieldAssertion::Simple {
-                field_name,
-                expected_value,
-                ..
-            } => {
-                // Simple field: generate assert_eq! with reference comparison
-                assertions.push(quote! {
-                    assert_eq!(#field_name, &#expected_value);
-                });
+    for (i, elem) in elements.iter().enumerate() {
+        match elem {
+            Pattern::Rest => {
+                pattern_parts.push(quote! { .. });
             }
-            FieldAssertion::StructPattern {
-                field_name,
-                path,
-                nested,
-                ..
-            } => {
-                // Struct pattern: recursively generate assertions
-                let assertion = generate_struct_pattern_assert(field_name, path, nested);
-                assertions.push(assertion);
-            }
-            FieldAssertion::TuplePattern {
-                field_name,
-                path,
-                elements,
-                ..
-            } => {
-                // Tuple pattern: generate match expression
-                let assertion = generate_tuple_pattern_assert(field_name, path, elements);
-                assertions.push(assertion);
-            }
-            FieldAssertion::UnitPattern {
-                field_name, path, ..
-            } => {
-                // Unit pattern: check if field matches the variant
-                let assertion = generate_unit_pattern_assert(field_name, path);
-                assertions.push(assertion);
-            }
-            #[cfg(feature = "regex")]
-            FieldAssertion::Regex {
-                field_name,
-                pattern,
-                ..
-            } => {
-                // Regex: compile pattern and check if field matches
-                assertions.push(quote! {
-                    {
-                        let re = ::regex::Regex::new(#pattern)
-                            .expect(concat!("Invalid regex pattern: ", #pattern));
-                        if !re.is_match(#field_name) {
-                            panic!(
-                                "Field `{}` does not match regex pattern `{}`\n  value: {:?}",
-                                stringify!(#field_name),
-                                #pattern,
-                                #field_name
-                            );
-                        }
-                    }
-                });
-            }
-            FieldAssertion::Comparison {
-                field_name,
-                op,
-                value,
-                ..
-            } => {
-                // Comparison: generate appropriate comparison assertion
-                let (op_str, error_msg) = match op {
-                    ComparisonOp::Less => ("<", "comparison"),
-                    ComparisonOp::LessEqual => ("<=", "comparison"),
-                    ComparisonOp::Greater => (">", "comparison"),
-                    ComparisonOp::GreaterEqual => (">=", "comparison"),
-                    ComparisonOp::Equal => ("==", "equality"),
-                    ComparisonOp::NotEqual => ("!=", "inequality"),
-                };
+            _ => {
+                let binding = quote::format_ident!("__elem_{}", i);
+                pattern_parts.push(quote! { #binding });
 
-                let comparison = match op {
-                    ComparisonOp::Less => quote! { #field_name < &(#value) },
-                    ComparisonOp::LessEqual => quote! { #field_name <= &(#value) },
-                    ComparisonOp::Greater => quote! { #field_name > &(#value) },
-                    ComparisonOp::GreaterEqual => quote! { #field_name >= &(#value) },
-                    ComparisonOp::Equal => quote! { #field_name == &(#value) },
-                    ComparisonOp::NotEqual => quote! { #field_name != &(#value) },
-                };
-
-                assertions.push(quote! {
-                    if !(#comparison) {
-                        panic!(
-                            "Field `{}` failed {}: {:?} {} {:?}",
-                            stringify!(#field_name),
-                            #error_msg,
-                            #field_name,
-                            #op_str,
-                            &(#value)
-                        );
-                    }
-                });
-            }
-            FieldAssertion::Range {
-                field_name, range, ..
-            } => {
-                // Range: use match expression for pattern matching
-                // Note: Full range (..) will fail at compile time with a clear error
-                // about .. patterns not being allowed, which is intentional
-                assertions.push(quote! {
-                    match #field_name {
-                        #range => {},
-                        _ => panic!(
-                            "Field `{}` not in range: {:?} not matching pattern",
-                            stringify!(#field_name),
-                            #field_name
-                        ),
-                    }
-                });
-            }
-            FieldAssertion::SlicePattern {
-                field_name,
-                elements,
-                ..
-            } => {
-                // Slice pattern: use Rust's native slice pattern matching!
-                // Generate pattern bindings and assertions for each element
-
-                let mut pattern_parts = Vec::new();
-                let mut bindings_and_assertions = Vec::new();
-
-                for (i, elem) in elements.iter().enumerate() {
-                    match elem {
-                        PatternElement::Rest => {
-                            pattern_parts.push(quote! { .. });
-                        }
-                        _ => {
-                            let binding = quote::format_ident!("__elem_{}", i);
-                            pattern_parts.push(quote! { #binding });
-
-                            let assertion = generate_pattern_element_assertion(&binding, elem);
-                            bindings_and_assertions.push(assertion);
-                        }
-                    }
-                }
-
-                // Use Rust's slice pattern matching in a match expression
-                assertions.push(quote! {
-                    match #field_name.as_slice() {
-                        [#(#pattern_parts),*] => {
-                            #(#bindings_and_assertions)*
-                        }
-                        _ => panic!(
-                            "Field `{}` pattern mismatch: {:?} doesn't match expected pattern",
-                            stringify!(#field_name),
-                            #field_name
-                        ),
-                    }
-                });
+                let assertion = generate_pattern_assertion(&quote! { #binding }, elem, true);
+                bindings_and_assertions.push(assertion);
             }
         }
     }
+
+    let slice_expr = quote! { (#value_expr).as_slice() };
 
     quote! {
-        #(#assertions)*
+        match #slice_expr {
+            [#(#pattern_parts),*] => {
+                #(#bindings_and_assertions)*
+            }
+            _ => panic!(
+                "Pattern mismatch: {:?} doesn't match expected pattern",
+                &#value_expr
+            ),
+        }
     }
 }
 
-/// Generate assertion for struct patterns (both standalone and enum variants)
-fn generate_struct_pattern_assert(
-    field_name: &syn::Ident,
-    path: &syn::Path,
-    nested: &Expected,
+// Generate comparison assertion
+fn generate_comparison_assertion(
+    value_expr: &TokenStream,
+    op: &ComparisonOp,
+    expected: &Expr,
+    is_ref: bool,
 ) -> TokenStream {
-    // Check if this looks like an enum variant
-    // Heuristic: if the path has multiple segments (e.g., Status::Active), it's likely an enum variant
-    // Single segment paths are likely regular structs (even though they start with uppercase)
-    let is_enum_variant = path.segments.len() > 1;
+    let (op_str, error_msg) = match op {
+        ComparisonOp::Less => ("<", "comparison"),
+        ComparisonOp::LessEqual => ("<=", "comparison"),
+        ComparisonOp::Greater => (">", "comparison"),
+        ComparisonOp::GreaterEqual => (">=", "comparison"),
+        ComparisonOp::Equal => ("==", "equality"),
+        ComparisonOp::NotEqual => ("!=", "inequality"),
+    };
 
-    if is_enum_variant {
-        // It's an enum variant with struct data
-        // Generate: match field { Path { fields.. } => check, _ => panic }
-
-        // Collect field names for destructuring
-        let field_names: Vec<_> = nested
-            .fields
-            .iter()
-            .map(|f| match f {
-                FieldAssertion::Simple { field_name, .. } => field_name.clone(),
-                FieldAssertion::StructPattern { field_name, .. } => field_name.clone(),
-                FieldAssertion::TuplePattern { field_name, .. } => field_name.clone(),
-                FieldAssertion::UnitPattern { field_name, .. } => field_name.clone(),
-                #[cfg(feature = "regex")]
-                FieldAssertion::Regex { field_name, .. } => field_name.clone(),
-                FieldAssertion::Comparison { field_name, .. } => field_name.clone(),
-                FieldAssertion::Range { field_name, .. } => field_name.clone(),
-                FieldAssertion::SlicePattern { field_name, .. } => field_name.clone(),
-            })
-            .collect();
-
-        let rest_pattern = if nested.rest {
-            quote! { , .. }
-        } else {
-            quote! {}
-        };
-
-        let nested_assertions = generate_assertions(nested);
-
-        quote! {
-            match #field_name {
-                #path { #(#field_names),* #rest_pattern } => {
-                    #nested_assertions
-                },
-                _ => panic!(
-                    "Field `{}` expected {}, got {:?}",
-                    stringify!(#field_name),
-                    stringify!(#path),
-                    #field_name
-                ),
-            }
-        }
-    } else {
-        // It's a regular struct, use recursive assert_struct!
-        // Generate the field assignments for the expected struct
-        let field_assignments = generate_struct_field_assignments(nested);
-
-        let rest_pattern = if nested.rest {
-            quote! { , .. }
-        } else {
-            quote! {}
+    if is_ref {
+        let comparison = match op {
+            ComparisonOp::Less => quote! { #value_expr < &(#expected) },
+            ComparisonOp::LessEqual => quote! { #value_expr <= &(#expected) },
+            ComparisonOp::Greater => quote! { #value_expr > &(#expected) },
+            ComparisonOp::GreaterEqual => quote! { #value_expr >= &(#expected) },
+            ComparisonOp::Equal => quote! { #value_expr == &(#expected) },
+            ComparisonOp::NotEqual => quote! { #value_expr != &(#expected) },
         };
 
         quote! {
-            assert_struct!(#field_name, #path {
-                #(#field_assignments),*
-                #rest_pattern
-            });
-        }
-    }
-}
-
-/// Generate assertion for tuple patterns (both standalone and enum variants)
-fn generate_tuple_pattern_assert(
-    field_name: &syn::Ident,
-    path: &Option<syn::Path>,
-    elements: &[PatternElement],
-) -> TokenStream {
-    if let Some(variant_path) = path {
-        // It's an enum variant with tuple data
-        // Check for special cases first
-
-        // Special handling for Some/None patterns
-        if is_option_some_path(variant_path) && elements.len() == 1 {
-            return generate_option_assertion(field_name, &elements[0]);
-        }
-
-        // General enum tuple variant
-        let element_names: Vec<_> = (0..elements.len())
-            .map(|i| quote::format_ident!("__elem_{}", i))
-            .collect();
-
-        let element_assertions = elements
-            .iter()
-            .zip(&element_names)
-            .map(|(elem, name)| generate_pattern_element_assertion(name, elem))
-            .collect::<Vec<_>>();
-
-        quote! {
-            match #field_name {
-                #variant_path(#(#element_names),*) => {
-                    #(#element_assertions)*
-                },
-                _ => panic!(
-                    "Field `{}` expected {}, got {:?}",
-                    stringify!(#field_name),
-                    stringify!(#variant_path),
-                    #field_name
-                ),
+            if !(#comparison) {
+                panic!(
+                    "Failed {}: {:?} {} {:?}",
+                    #error_msg,
+                    #value_expr,
+                    #op_str,
+                    &(#expected)
+                );
             }
         }
     } else {
-        // Plain tuple
-        let element_names: Vec<_> = (0..elements.len())
-            .map(|i| quote::format_ident!("__tuple_elem_{}", i))
-            .collect();
-
-        let destructure = quote! {
-            let (#(#element_names),*) = &#field_name;
+        let comparison = match op {
+            ComparisonOp::Less => quote! { &#value_expr < &(#expected) },
+            ComparisonOp::LessEqual => quote! { &#value_expr <= &(#expected) },
+            ComparisonOp::Greater => quote! { &#value_expr > &(#expected) },
+            ComparisonOp::GreaterEqual => quote! { &#value_expr >= &(#expected) },
+            ComparisonOp::Equal => quote! { &#value_expr == &(#expected) },
+            ComparisonOp::NotEqual => quote! { &#value_expr != &(#expected) },
         };
 
-        let element_assertions = elements
-            .iter()
-            .zip(&element_names)
-            .map(|(elem, name)| generate_pattern_element_assertion(name, elem))
-            .collect::<Vec<_>>();
-
         quote! {
-            {
-                #destructure
-                #(#element_assertions)*
+            if !(#comparison) {
+                panic!(
+                    "Failed {}: {:?} {} {:?}",
+                    #error_msg,
+                    &#value_expr,
+                    #op_str,
+                    &(#expected)
+                );
             }
         }
     }
 }
 
-/// Generate assertion for a single pattern element
-fn generate_pattern_element_assertion(
-    elem_name: &syn::Ident,
-    element: &PatternElement,
-) -> TokenStream {
-    match element {
-        PatternElement::Simple(expected) => {
-            // Check if this is a string literal that needs transformation
-            let transformed = transform_expected_value(expected);
-            quote! {
-                assert_eq!(#elem_name, &#transformed);
-            }
-        }
-        PatternElement::Comparison(op, value) => {
-            let (op_str, error_msg) = match op {
-                ComparisonOp::Less => ("<", "comparison"),
-                ComparisonOp::LessEqual => ("<=", "comparison"),
-                ComparisonOp::Greater => (">", "comparison"),
-                ComparisonOp::GreaterEqual => (">=", "comparison"),
-                ComparisonOp::Equal => ("==", "equality"),
-                ComparisonOp::NotEqual => ("!=", "inequality"),
-            };
-
-            let comparison = match op {
-                ComparisonOp::Less => quote! { #elem_name < &(#value) },
-                ComparisonOp::LessEqual => quote! { #elem_name <= &(#value) },
-                ComparisonOp::Greater => quote! { #elem_name > &(#value) },
-                ComparisonOp::GreaterEqual => quote! { #elem_name >= &(#value) },
-                ComparisonOp::Equal => quote! { #elem_name == &(#value) },
-                ComparisonOp::NotEqual => quote! { #elem_name != &(#value) },
-            };
-
-            quote! {
-                if !(#comparison) {
-                    panic!(
-                        "Element failed {}: {:?} {} {:?}",
-                        #error_msg,
-                        #elem_name,
-                        #op_str,
-                        &(#value)
-                    );
-                }
-            }
-        }
-        #[cfg(feature = "regex")]
-        PatternElement::Regex(pattern) => {
-            quote! {
-                {
-                    let re = ::regex::Regex::new(#pattern)
-                        .expect(concat!("Invalid regex pattern: ", #pattern));
-                    if !re.is_match(#elem_name) {
-                        panic!(
-                            "Element does not match regex pattern `{}`\n  value: {:?}",
-                            #pattern,
-                            #elem_name
-                        );
-                    }
-                }
-            }
-        }
-        PatternElement::Struct(struct_path, nested) => {
-            // Check if this is an enum variant or a regular struct
-            let is_enum_variant = struct_path.segments.len() > 1;
-
-            if is_enum_variant {
-                // It's an enum variant - generate a match expression
-                let field_names: Vec<_> = nested
-                    .fields
-                    .iter()
-                    .map(|f| match f {
-                        FieldAssertion::Simple { field_name, .. } => field_name.clone(),
-                        FieldAssertion::StructPattern { field_name, .. } => field_name.clone(),
-                        FieldAssertion::TuplePattern { field_name, .. } => field_name.clone(),
-                        FieldAssertion::UnitPattern { field_name, .. } => field_name.clone(),
-                        #[cfg(feature = "regex")]
-                        FieldAssertion::Regex { field_name, .. } => field_name.clone(),
-                        FieldAssertion::Comparison { field_name, .. } => field_name.clone(),
-                        FieldAssertion::Range { field_name, .. } => field_name.clone(),
-                        FieldAssertion::SlicePattern { field_name, .. } => field_name.clone(),
-                    })
-                    .collect();
-
-                let rest_pattern = if nested.rest {
-                    quote! { , .. }
-                } else {
-                    quote! {}
-                };
-
-                let nested_assertions = generate_assertions(nested);
-
-                quote! {
-                    match #elem_name {
-                        #struct_path { #(#field_names),* #rest_pattern } => {
-                            #nested_assertions
-                        },
-                        _ => panic!(
-                            "Element expected {}, got {:?}",
-                            stringify!(#struct_path),
-                            #elem_name
-                        ),
-                    }
-                }
-            } else {
-                // Regular struct - use recursive assert_struct!
-                let field_assignments = generate_struct_field_assignments(nested);
-                let rest_pattern = if nested.rest {
-                    quote! { , .. }
-                } else {
-                    quote! {}
-                };
-
-                quote! {
-                    assert_struct!(#elem_name, #struct_path {
-                        #(#field_assignments),*
-                        #rest_pattern
-                    });
-                }
-            }
-        }
-        PatternElement::Rest => {
-            // Rest patterns don't generate assertions themselves
-            // They're handled in the slice pattern logic
-            quote! {}
-        }
-        PatternElement::SlicePattern(elements) => {
-            // Handle slice patterns inside other patterns (e.g., Some([1, 2, 3]))
-            // Generate pattern bindings and assertions for each element
-            let mut pattern_parts = Vec::new();
-            let mut bindings_and_assertions = Vec::new();
-
-            for (i, elem) in elements.iter().enumerate() {
-                match elem {
-                    PatternElement::Rest => {
-                        pattern_parts.push(quote! { .. });
-                    }
-                    _ => {
-                        let binding = quote::format_ident!("__slice_elem_{}", i);
-                        pattern_parts.push(quote! { #binding });
-
-                        let assertion = generate_pattern_element_assertion(&binding, elem);
-                        bindings_and_assertions.push(assertion);
-                    }
-                }
-            }
-
-            // Use Rust's slice pattern matching in a match expression
-            quote! {
-                match #elem_name.as_slice() {
-                    [#(#pattern_parts),*] => {
-                        #(#bindings_and_assertions)*
-                    }
-                    _ => panic!(
-                        "Element pattern mismatch: {:?} doesn't match expected slice pattern",
-                        #elem_name
-                    ),
-                }
-            }
-        }
-        PatternElement::Tuple(path, elements) => {
-            // Handle nested tuples or enum variants within tuples
-            if let Some(variant_path) = path {
-                // It's an enum variant like Some(42) or None
-                if elements.is_empty() {
-                    // Unit variant like None
-                    // Special handling for None
-                    if is_option_none_path(variant_path) {
-                        quote! {
-                            match #elem_name {
-                                None => {},
-                                Some(_) => panic!(
-                                    concat!("Element expected None, got Some")
-                                ),
-                            }
-                        }
-                    } else {
-                        // General unit variant
-                        quote! {
-                            match #elem_name {
-                                #variant_path => {},
-                                _ => panic!(
-                                    "Element expected {}, got {:?}",
-                                    stringify!(#variant_path),
-                                    #elem_name
-                                ),
-                            }
-                        }
-                    }
-                } else {
-                    // Tuple variant with data
-                    // Special handling for Some
-                    if is_option_some_path(variant_path) && elements.len() == 1 {
-                        // Generate specialized Option handling
-                        let inner_assertion = generate_pattern_element_assertion(
-                            &quote::format_ident!("inner"),
-                            &elements[0],
-                        );
-                        quote! {
-                            match #elem_name {
-                                Some(inner) => {
-                                    #inner_assertion
-                                },
-                                None => panic!(
-                                    concat!("Element expected Some(...), got None")
-                                ),
-                            }
-                        }
-                    } else {
-                        // General enum tuple variant
-                        let element_names: Vec<_> = (0..elements.len())
-                            .map(|i| quote::format_ident!("__elem_{}", i))
-                            .collect();
-
-                        let element_assertions = elements
-                            .iter()
-                            .zip(&element_names)
-                            .map(|(elem, name)| generate_pattern_element_assertion(name, elem))
-                            .collect::<Vec<_>>();
-
-                        quote! {
-                            match #elem_name {
-                                #variant_path(#(#element_names),*) => {
-                                    #(#element_assertions)*
-                                },
-                                _ => panic!(
-                                    "Element expected {}, got {:?}",
-                                    stringify!(#variant_path),
-                                    #elem_name
-                                ),
-                            }
-                        }
-                    }
-                }
-            } else {
-                // Plain nested tuple
-                let element_names: Vec<_> = (0..elements.len())
-                    .map(|i| quote::format_ident!("__tuple_{}", i))
-                    .collect();
-
-                let destructure = quote! {
-                    let (#(#element_names),*) = &#elem_name;
-                };
-
-                let element_assertions = elements
-                    .iter()
-                    .zip(&element_names)
-                    .map(|(elem, name)| generate_pattern_element_assertion(name, elem))
-                    .collect::<Vec<_>>();
-
-                quote! {
-                    {
-                        #destructure
-                        #(#element_assertions)*
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Generate assertion for unit patterns (enum variants with no data)
-fn generate_unit_pattern_assert(field_name: &syn::Ident, path: &syn::Path) -> TokenStream {
-    // Special handling for None
-    if is_option_none_path(path) {
-        quote! {
-            match #field_name {
-                None => {},
-                Some(_) => panic!(
-                    concat!("Field `", stringify!(#field_name), "` expected None, got Some")
-                ),
-            }
-        }
-    } else {
-        // General unit variant
-        quote! {
-            match #field_name {
-                #path => {},
-                _ => panic!(
-                    "Field `{}` expected {}, got {:?}",
-                    stringify!(#field_name),
-                    stringify!(#path),
-                    #field_name
-                ),
-            }
-        }
-    }
-}
-
-/// Special handling for Option::Some patterns
-fn generate_option_assertion(field_name: &syn::Ident, element: &PatternElement) -> TokenStream {
-    match element {
-        PatternElement::Simple(expected) => {
-            let transformed = transform_expected_value(expected);
-            quote! {
-                match #field_name {
-                    Some(inner) => {
-                        assert_eq!(inner, &#transformed);
-                    },
-                    None => panic!(
-                        concat!("Field `", stringify!(#field_name), "` expected Some(...), got None")
-                    ),
-                }
-            }
-        }
-        PatternElement::Comparison(op, value) => {
-            let (op_str, error_msg) = match op {
-                ComparisonOp::Less => ("<", "comparison"),
-                ComparisonOp::LessEqual => ("<=", "comparison"),
-                ComparisonOp::Greater => (">", "comparison"),
-                ComparisonOp::GreaterEqual => (">=", "comparison"),
-                ComparisonOp::Equal => ("==", "equality"),
-                ComparisonOp::NotEqual => ("!=", "inequality"),
-            };
-
-            let comparison = match op {
-                ComparisonOp::Less => quote! { inner < &(#value) },
-                ComparisonOp::LessEqual => quote! { inner <= &(#value) },
-                ComparisonOp::Greater => quote! { inner > &(#value) },
-                ComparisonOp::GreaterEqual => quote! { inner >= &(#value) },
-                ComparisonOp::Equal => quote! { inner == &(#value) },
-                ComparisonOp::NotEqual => quote! { inner != &(#value) },
-            };
-
-            quote! {
-                match #field_name {
-                    Some(inner) => {
-                        if !(#comparison) {
-                            panic!(
-                                "Field `{}` failed {}: Some({:?}) {} {:?}",
-                                stringify!(#field_name),
-                                #error_msg,
-                                inner,
-                                #op_str,
-                                &(#value)
-                            );
-                        }
-                    },
-                    None => panic!(
-                        concat!("Field `", stringify!(#field_name), "` expected Some(...), got None")
-                    ),
-                }
-            }
-        }
-        #[cfg(feature = "regex")]
-        PatternElement::Regex(pattern) => {
-            quote! {
-                match #field_name {
-                    Some(inner) => {
-                        let re = ::regex::Regex::new(#pattern)
-                            .expect(concat!("Invalid regex pattern: ", #pattern));
-                        if !re.is_match(inner) {
-                            panic!(
-                                "Field `{}` does not match regex pattern `{}`\n  value: Some({:?})",
-                                stringify!(#field_name),
-                                #pattern,
-                                inner
-                            );
-                        }
-                    },
-                    None => panic!(
-                        concat!("Field `", stringify!(#field_name), "` expected Some(...), got None")
-                    ),
-                }
-            }
-        }
-        PatternElement::Struct(struct_path, nested) => {
-            // Some(Struct { ... }) pattern
-            let field_assignments = generate_struct_field_assignments(nested);
-            let rest_pattern = if nested.rest {
-                quote! { , .. }
-            } else {
-                quote! {}
-            };
-
-            quote! {
-                match #field_name {
-                    Some(inner) => {
-                        assert_struct!(inner, #struct_path {
-                            #(#field_assignments),*
-                            #rest_pattern
-                        });
-                    },
-                    None => panic!(
-                        concat!("Field `", stringify!(#field_name), "` expected Some(...), got None")
-                    ),
-                }
-            }
-        }
-        PatternElement::Rest => {
-            // Rest patterns don't make sense inside Option
-            panic!("Rest patterns (..) are not supported inside Option");
-        }
-        PatternElement::SlicePattern(elements) => {
-            // Handle Some([1, 2, 3]) patterns
-            let mut pattern_parts = Vec::new();
-            let mut bindings_and_assertions = Vec::new();
-
-            for (i, elem) in elements.iter().enumerate() {
-                match elem {
-                    PatternElement::Rest => {
-                        pattern_parts.push(quote! { .. });
-                    }
-                    _ => {
-                        let binding = quote::format_ident!("__opt_slice_elem_{}", i);
-                        pattern_parts.push(quote! { #binding });
-
-                        let assertion = generate_pattern_element_assertion(&binding, elem);
-                        bindings_and_assertions.push(assertion);
-                    }
-                }
-            }
-
-            quote! {
-                match #field_name {
-                    Some(inner) => {
-                        match inner.as_slice() {
-                            [#(#pattern_parts),*] => {
-                                #(#bindings_and_assertions)*
-                            }
-                            _ => panic!(
-                                "Field `{}` pattern mismatch: Some({:?}) doesn't match expected slice pattern",
-                                stringify!(#field_name),
-                                inner
-                            ),
-                        }
-                    },
-                    None => panic!(
-                        concat!("Field `", stringify!(#field_name), "` expected Some([...]), got None")
-                    ),
-                }
-            }
-        }
-        PatternElement::Tuple(_path, _elements) => {
-            // This shouldn't happen - Tuple patterns inside Some() should be handled differently
-            // But for completeness, we can just panic with an error message
-            panic!("Complex tuple patterns inside Option are not yet supported in this context");
-        }
-    }
-}
-
-/// Transform expected values (e.g., string literals to String)
+// Transform expected values (e.g., string literals to String)
 fn transform_expected_value(expr: &Expr) -> Expr {
     match expr {
         Expr::Lit(lit) if matches!(lit.lit, syn::Lit::Str(_)) => {
@@ -803,275 +496,7 @@ fn transform_expected_value(expr: &Expr) -> Expr {
     }
 }
 
-/// Generate field assignments for nested struct patterns
-fn generate_struct_field_assignments(nested: &Expected) -> Vec<TokenStream> {
-    let mut field_assignments = Vec::new();
-
-    for field in &nested.fields {
-        match field {
-            FieldAssertion::Simple {
-                field_name,
-                expected_value,
-                ..
-            } => {
-                field_assignments.push(quote! {
-                    #field_name: #expected_value
-                });
-            }
-            FieldAssertion::StructPattern {
-                field_name,
-                path,
-                nested,
-                ..
-            } => {
-                // For nested structs in field assignments
-                let nested_struct = generate_nested_struct(path, nested);
-                field_assignments.push(quote! {
-                    #field_name: #nested_struct
-                });
-            }
-            FieldAssertion::TuplePattern {
-                field_name,
-                path,
-                elements,
-                ..
-            } => {
-                // For tuples in field assignments
-                if let Some(variant_path) = path {
-                    // Enum variant
-                    let element_values: Vec<TokenStream> = elements
-                        .iter()
-                        .map(|e| match e {
-                            PatternElement::Simple(expr) => quote! { #expr },
-                            PatternElement::Struct(struct_path, nested) => {
-                                // Generate the nested struct
-                                let nested_struct = generate_nested_struct(struct_path, nested);
-                                quote! { #nested_struct }
-                            }
-                            PatternElement::Comparison(op, value) => {
-                                // For comparisons in field assignments, pass through the operator
-                                let op_tokens = match op {
-                                    ComparisonOp::Less => quote! { < },
-                                    ComparisonOp::LessEqual => quote! { <= },
-                                    ComparisonOp::Greater => quote! { > },
-                                    ComparisonOp::GreaterEqual => quote! { >= },
-                                    ComparisonOp::Equal => quote! { == },
-                                    ComparisonOp::NotEqual => quote! { != },
-                                };
-                                quote! { #op_tokens #value }
-                            }
-                            #[cfg(feature = "regex")]
-                            PatternElement::Regex(pattern) => {
-                                quote! { =~ #pattern }
-                            }
-                            PatternElement::Rest => {
-                                quote! { .. }
-                            }
-                            PatternElement::SlicePattern(inner_elements) => {
-                                // For nested slice patterns in field assignments
-                                let inner_values = generate_pattern_element_values(inner_elements);
-                                quote! { [#(#inner_values),*] }
-                            }
-                            PatternElement::Tuple(path, inner_elements) => {
-                                // For nested tuples/enums in field assignments, generate the pattern
-                                if let Some(variant_path) = path {
-                                    // It's an enum variant
-                                    let inner_values =
-                                        generate_pattern_element_values(inner_elements);
-                                    quote! { #variant_path(#(#inner_values),*) }
-                                } else {
-                                    // Plain tuple
-                                    let inner_values =
-                                        generate_pattern_element_values(inner_elements);
-                                    quote! { (#(#inner_values),*) }
-                                }
-                            }
-                        })
-                        .collect();
-                    field_assignments.push(quote! {
-                        #field_name: #variant_path(#(#element_values),*)
-                    });
-                } else {
-                    // Plain tuple
-                    let element_values: Vec<TokenStream> = elements
-                        .iter()
-                        .map(|e| match e {
-                            PatternElement::Simple(expr) => quote! { #expr },
-                            PatternElement::Struct(struct_path, nested) => {
-                                // Generate the nested struct
-                                let nested_struct = generate_nested_struct(struct_path, nested);
-                                quote! { #nested_struct }
-                            }
-                            PatternElement::Comparison(op, value) => {
-                                // For comparisons in field assignments, pass through the operator
-                                let op_tokens = match op {
-                                    ComparisonOp::Less => quote! { < },
-                                    ComparisonOp::LessEqual => quote! { <= },
-                                    ComparisonOp::Greater => quote! { > },
-                                    ComparisonOp::GreaterEqual => quote! { >= },
-                                    ComparisonOp::Equal => quote! { == },
-                                    ComparisonOp::NotEqual => quote! { != },
-                                };
-                                quote! { #op_tokens #value }
-                            }
-                            #[cfg(feature = "regex")]
-                            PatternElement::Regex(pattern) => {
-                                quote! { =~ #pattern }
-                            }
-                            PatternElement::Rest => {
-                                quote! { .. }
-                            }
-                            PatternElement::SlicePattern(inner_elements) => {
-                                // For nested slice patterns in field assignments
-                                let inner_values = generate_pattern_element_values(inner_elements);
-                                quote! { [#(#inner_values),*] }
-                            }
-                            PatternElement::Tuple(path, inner_elements) => {
-                                // For nested tuples/enums in field assignments, generate the pattern
-                                if let Some(variant_path) = path {
-                                    // It's an enum variant
-                                    let inner_values =
-                                        generate_pattern_element_values(inner_elements);
-                                    quote! { #variant_path(#(#inner_values),*) }
-                                } else {
-                                    // Plain tuple
-                                    let inner_values =
-                                        generate_pattern_element_values(inner_elements);
-                                    quote! { (#(#inner_values),*) }
-                                }
-                            }
-                        })
-                        .collect();
-                    field_assignments.push(quote! {
-                        #field_name: (#(#element_values),*)
-                    });
-                }
-            }
-            FieldAssertion::UnitPattern {
-                field_name, path, ..
-            } => {
-                field_assignments.push(quote! {
-                    #field_name: #path
-                });
-            }
-            #[cfg(feature = "regex")]
-            FieldAssertion::Regex {
-                field_name,
-                pattern,
-                ..
-            } => {
-                // For regex in nested structs, we pass through with =~ syntax
-                field_assignments.push(quote! {
-                    #field_name: =~ #pattern
-                });
-            }
-            FieldAssertion::Comparison {
-                field_name,
-                op,
-                value,
-                ..
-            } => {
-                // For comparisons in nested structs, we pass through the operator
-                let op_tokens = match op {
-                    ComparisonOp::Less => quote! { < },
-                    ComparisonOp::LessEqual => quote! { <= },
-                    ComparisonOp::Greater => quote! { > },
-                    ComparisonOp::GreaterEqual => quote! { >= },
-                    ComparisonOp::Equal => quote! { == },
-                    ComparisonOp::NotEqual => quote! { != },
-                };
-                field_assignments.push(quote! {
-                    #field_name: #op_tokens #value
-                });
-            }
-            FieldAssertion::Range {
-                field_name, range, ..
-            } => {
-                // For ranges in nested structs, pass through the range expression
-                field_assignments.push(quote! {
-                    #field_name: #range
-                });
-            }
-            FieldAssertion::SlicePattern {
-                field_name,
-                elements,
-                ..
-            } => {
-                // For slice patterns in nested structs, generate array literal with pattern elements
-                let element_values = generate_pattern_element_values(elements);
-                field_assignments.push(quote! {
-                    #field_name: [#(#element_values),*]
-                });
-            }
-        }
-    }
-
-    field_assignments
-}
-
-/// Generate values from pattern elements for use in field assignments
-fn generate_pattern_element_values(elements: &[PatternElement]) -> Vec<TokenStream> {
-    elements
-        .iter()
-        .map(|e| match e {
-            PatternElement::Simple(expr) => quote! { #expr },
-            PatternElement::Comparison(op, value) => {
-                let op_tokens = match op {
-                    ComparisonOp::Less => quote! { < },
-                    ComparisonOp::LessEqual => quote! { <= },
-                    ComparisonOp::Greater => quote! { > },
-                    ComparisonOp::GreaterEqual => quote! { >= },
-                    ComparisonOp::Equal => quote! { == },
-                    ComparisonOp::NotEqual => quote! { != },
-                };
-                quote! { #op_tokens #value }
-            }
-            #[cfg(feature = "regex")]
-            PatternElement::Regex(pattern) => {
-                quote! { =~ #pattern }
-            }
-            PatternElement::Struct(struct_path, nested) => {
-                let nested_struct = generate_nested_struct(struct_path, nested);
-                quote! { #nested_struct }
-            }
-            PatternElement::Rest => {
-                quote! { .. }
-            }
-            PatternElement::SlicePattern(inner_elements) => {
-                let inner_values = generate_pattern_element_values(inner_elements);
-                quote! { [#(#inner_values),*] }
-            }
-            PatternElement::Tuple(path, inner_elements) => {
-                if let Some(variant_path) = path {
-                    let inner_values = generate_pattern_element_values(inner_elements);
-                    quote! { #variant_path(#(#inner_values),*) }
-                } else {
-                    let inner_values = generate_pattern_element_values(inner_elements);
-                    quote! { (#(#inner_values),*) }
-                }
-            }
-        })
-        .collect()
-}
-
-fn generate_nested_struct(type_name: &syn::Path, expected: &Expected) -> TokenStream {
-    let field_assignments = generate_struct_field_assignments(expected);
-
-    let rest_pattern = if expected.rest {
-        quote! { , .. }
-    } else {
-        quote! {}
-    };
-
-    quote! {
-        #type_name {
-            #(#field_assignments),*
-            #rest_pattern
-        }
-    }
-}
-
-/// Check if a path refers to Option::Some
+// Check if a path refers to Option::Some
 fn is_option_some_path(path: &syn::Path) -> bool {
     if let Some(segment) = path.segments.last() {
         segment.ident == "Some"
@@ -1080,7 +505,7 @@ fn is_option_some_path(path: &syn::Path) -> bool {
     }
 }
 
-/// Check if a path refers to Option::None
+// Check if a path refers to Option::None
 fn is_option_none_path(path: &syn::Path) -> bool {
     if let Some(segment) = path.segments.last() {
         segment.ident == "None"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::{AssertStruct, ComparisonOp, Expected, FieldAssertion, PatternElement};
+use crate::{AssertStruct, ComparisonOp, Expected, FieldAssertion, Pattern};
 use syn::{Result, Token, parse::Parse, parse::ParseStream, punctuated::Punctuated};
 
 pub fn parse(input: proc_macro::TokenStream) -> syn::Result<AssertStruct> {
@@ -9,16 +9,9 @@ impl Parse for AssertStruct {
     fn parse(input: ParseStream) -> Result<Self> {
         let value = input.parse()?;
         let _: Token![,] = input.parse()?;
-        let type_name = input.parse()?;
-        let content;
-        syn::braced!(content in input);
-        let expected = content.parse()?;
+        let pattern = parse_pattern(input)?;
 
-        Ok(AssertStruct {
-            value,
-            type_name,
-            expected,
-        })
+        Ok(AssertStruct { value, pattern })
     }
 }
 
@@ -54,211 +47,195 @@ impl Parse for Expected {
     }
 }
 
+// Parse any pattern at any level
+fn parse_pattern(input: ParseStream) -> Result<Pattern> {
+    // Check for .. but need to distinguish from range patterns (..n, ..=n)
+    if input.peek(Token![..]) {
+        let fork = input.fork();
+        let _: Token![..] = fork.parse()?;
+
+        // Check if this is a range pattern (..n or ..=n)
+        if fork.peek(Token![=]) || (!fork.is_empty() && !fork.peek(Token![,])) {
+            // This is a range pattern, fall through to parse as expression
+        } else {
+            // This is a rest pattern
+            let _: Token![..] = input.parse()?;
+            return Ok(Pattern::Rest);
+        }
+    }
+
+    // Check for comparison operators: <, <=, >, >=
+    if input.peek(Token![<]) {
+        let _: Token![<] = input.parse()?;
+        if input.peek(Token![=]) {
+            let _: Token![=] = input.parse()?;
+            let value = input.parse()?;
+            return Ok(Pattern::Comparison(ComparisonOp::LessEqual, value));
+        } else {
+            let value = input.parse()?;
+            return Ok(Pattern::Comparison(ComparisonOp::Less, value));
+        }
+    }
+
+    if input.peek(Token![>]) {
+        let _: Token![>] = input.parse()?;
+        if input.peek(Token![=]) {
+            let _: Token![=] = input.parse()?;
+            let value = input.parse()?;
+            return Ok(Pattern::Comparison(ComparisonOp::GreaterEqual, value));
+        } else {
+            let value = input.parse()?;
+            return Ok(Pattern::Comparison(ComparisonOp::Greater, value));
+        }
+    }
+
+    // Check for != operator
+    if input.peek(Token![!]) {
+        let fork = input.fork();
+        if fork.parse::<Token![!]>().is_ok() && fork.peek(Token![=]) {
+            let _: Token![!] = input.parse()?;
+            let _: Token![=] = input.parse()?;
+            let value = input.parse()?;
+            return Ok(Pattern::Comparison(ComparisonOp::NotEqual, value));
+        }
+    }
+
+    // Check for == or =~ operators
+    if input.peek(Token![=]) {
+        let fork = input.fork();
+        if fork.parse::<Token![=]>().is_ok() {
+            if fork.peek(Token![=]) {
+                // == operator
+                let _: Token![=] = input.parse()?;
+                let _: Token![=] = input.parse()?;
+                let value = input.parse()?;
+                return Ok(Pattern::Comparison(ComparisonOp::Equal, value));
+            }
+            #[cfg(feature = "regex")]
+            if fork.peek(Token![~]) {
+                // =~ regex operator
+                let _: Token![=] = input.parse()?;
+                let _: Token![~] = input.parse()?;
+                let lit: syn::LitStr = input.parse()?;
+                return Ok(Pattern::Regex(lit.value()));
+            }
+        }
+    }
+
+    // Check for slice pattern [...]
+    if input.peek(syn::token::Bracket) {
+        let content;
+        syn::bracketed!(content in input);
+        let elements = parse_pattern_list(&content)?;
+        return Ok(Pattern::Slice(elements));
+    }
+
+    // Check for tuple pattern (...)
+    if input.peek(syn::token::Paren) {
+        let content;
+        syn::parenthesized!(content in input);
+        let elements = parse_pattern_list(&content)?;
+        return Ok(Pattern::Tuple {
+            path: None,
+            elements,
+        });
+    }
+
+    // Try to parse a path (could be Type, Some, Status::Active, etc.)
+    let fork = input.fork();
+    if let Ok(path) = fork.parse::<syn::Path>() {
+        // Check for struct pattern: Path { fields }
+        if fork.peek(syn::token::Brace) {
+            // Commit to parsing the path
+            let path: syn::Path = input.parse()?;
+            let content;
+            syn::braced!(content in input);
+            let expected: Expected = content.parse()?;
+            return Ok(Pattern::Struct {
+                path,
+                fields: expected.fields,
+                rest: expected.rest,
+            });
+        }
+
+        // Check for tuple pattern: Path(...)
+        if fork.peek(syn::token::Paren) {
+            // Commit to parsing the path
+            let path: syn::Path = input.parse()?;
+            let content;
+            syn::parenthesized!(content in input);
+
+            // Check if the content contains special syntax
+            let fork = content.fork();
+            let has_special = check_for_special_syntax(&fork);
+
+            if has_special {
+                let elements = parse_pattern_list(&content)?;
+                return Ok(Pattern::Tuple {
+                    path: Some(path),
+                    elements,
+                });
+            } else {
+                // Simple expression like Some(vec![1, 2, 3])
+                let expr = content.parse()?;
+                return Ok(Pattern::Tuple {
+                    path: Some(path),
+                    elements: vec![Pattern::Simple(expr)],
+                });
+            }
+        }
+
+        // Check if it's a unit variant (path with no brackets)
+        // Heuristic: starts with uppercase
+        if let Some(segment) = path.segments.last() {
+            let name = segment.ident.to_string();
+            if name.chars().next().is_some_and(|c| c.is_uppercase()) {
+                // Likely a unit variant like None or Status::Inactive
+                let path: syn::Path = input.parse()?;
+                return Ok(Pattern::Tuple {
+                    path: Some(path),
+                    elements: vec![],
+                });
+            }
+        }
+    }
+
+    // Fall back to simple expression or range
+    let expr: syn::Expr = input.parse()?;
+
+    // Check if it's a range expression
+    if matches!(expr, syn::Expr::Range(_)) {
+        Ok(Pattern::Range(expr))
+    } else {
+        Ok(Pattern::Simple(expr))
+    }
+}
+
+// Parse a list of patterns separated by commas
+fn parse_pattern_list(input: ParseStream) -> Result<Vec<Pattern>> {
+    let mut patterns = Vec::new();
+
+    while !input.is_empty() {
+        patterns.push(parse_pattern(input)?);
+
+        if !input.is_empty() {
+            let _: Token![,] = input.parse()?;
+        }
+    }
+
+    Ok(patterns)
+}
+
 impl Parse for FieldAssertion {
     fn parse(input: ParseStream) -> Result<Self> {
         let field_name: syn::Ident = input.parse()?;
         let _: Token![:] = input.parse()?;
+        let pattern = parse_pattern(input)?;
 
-        // Check for comparison operators at the top level: <, <=, >, >=, ==, !=
-        if input.peek(Token![<]) {
-            let _: Token![<] = input.parse()?;
-            if input.peek(Token![=]) {
-                let _: Token![=] = input.parse()?;
-                let value = input.parse()?;
-                return Ok(FieldAssertion::Comparison {
-                    field_name,
-                    op: ComparisonOp::LessEqual,
-                    value,
-                });
-            } else {
-                let value = input.parse()?;
-                return Ok(FieldAssertion::Comparison {
-                    field_name,
-                    op: ComparisonOp::Less,
-                    value,
-                });
-            }
-        }
-
-        if input.peek(Token![>]) {
-            let _: Token![>] = input.parse()?;
-            if input.peek(Token![=]) {
-                let _: Token![=] = input.parse()?;
-                let value = input.parse()?;
-                return Ok(FieldAssertion::Comparison {
-                    field_name,
-                    op: ComparisonOp::GreaterEqual,
-                    value,
-                });
-            } else {
-                let value = input.parse()?;
-                return Ok(FieldAssertion::Comparison {
-                    field_name,
-                    op: ComparisonOp::Greater,
-                    value,
-                });
-            }
-        }
-
-        // Check for != operator
-        if input.peek(Token![!]) {
-            let fork = input.fork();
-            if fork.parse::<Token![!]>().is_ok() && fork.peek(Token![=]) {
-                let _: Token![!] = input.parse()?;
-                let _: Token![=] = input.parse()?;
-                let value = input.parse()?;
-                return Ok(FieldAssertion::Comparison {
-                    field_name,
-                    op: ComparisonOp::NotEqual,
-                    value,
-                });
-            }
-        }
-
-        // Check for == or =~ operators
-        if input.peek(Token![=]) {
-            let fork = input.fork();
-            if fork.parse::<Token![=]>().is_ok() {
-                if fork.peek(Token![=]) {
-                    // This is the == operator
-                    let _: Token![=] = input.parse()?;
-                    let _: Token![=] = input.parse()?;
-                    let value = input.parse()?;
-                    return Ok(FieldAssertion::Comparison {
-                        field_name,
-                        op: ComparisonOp::Equal,
-                        value,
-                    });
-                }
-                #[cfg(feature = "regex")]
-                if fork.peek(Token![~]) {
-                    // This is the =~ regex operator
-                    let _: Token![=] = input.parse()?;
-                    let _: Token![~] = input.parse()?;
-
-                    // Expect a string literal (raw or regular)
-                    let lit: syn::LitStr = input.parse()?;
-                    return Ok(FieldAssertion::Regex {
-                        field_name,
-                        pattern: lit.value(),
-                    });
-                }
-            }
-        }
-
-        // Check if this is a slice pattern [...]
-        if input.peek(syn::token::Bracket) {
-            let content;
-            syn::bracketed!(content in input);
-
-            let elements = parse_slice_elements(&content)?;
-
-            return Ok(FieldAssertion::SlicePattern {
-                field_name,
-                elements,
-            });
-        }
-
-        // Check if this is a plain tuple (no path prefix)
-        if input.peek(syn::token::Paren) {
-            let content;
-            syn::parenthesized!(content in input);
-
-            let elements = parse_tuple_elements(&content)?;
-
-            return Ok(FieldAssertion::TuplePattern {
-                field_name,
-                path: None, // No path for plain tuples
-                elements,
-            });
-        }
-
-        // Try to parse a path (could be Type, Some, Status::Active, etc.)
-        let fork = input.fork();
-        if let Ok(path) = fork.parse::<syn::Path>() {
-            // We have a path, check what follows
-
-            // Check for struct pattern: Path { fields }
-            if fork.peek(syn::token::Brace) {
-                // Commit to parsing the path
-                let path: syn::Path = input.parse()?;
-                let content;
-                syn::braced!(content in input);
-                let nested = content.parse()?;
-
-                return Ok(FieldAssertion::StructPattern {
-                    field_name,
-                    path,
-                    nested,
-                });
-            }
-
-            // Check for tuple pattern: Path(...)
-            if fork.peek(syn::token::Paren) {
-                // Commit to parsing the path
-                let path: syn::Path = input.parse()?;
-
-                // Now we need to check if the parentheses contain special syntax
-                // We'll parse the parenthesized content manually
-                let elements = parse_variant_tuple_contents(input)?;
-
-                return Ok(FieldAssertion::TuplePattern {
-                    field_name,
-                    path: Some(path),
-                    elements,
-                });
-            }
-
-            // Check if it's a unit variant (path with no brackets)
-            // We need to distinguish between unit variants and simple values
-            // For now, we'll check if it starts with uppercase (convention)
-            if let Some(segment) = path.segments.last() {
-                let name = segment.ident.to_string();
-                if name.chars().next().is_some_and(|c| c.is_uppercase()) {
-                    // Likely a unit variant like None or Status::Inactive
-                    let path: syn::Path = input.parse()?;
-                    return Ok(FieldAssertion::UnitPattern { field_name, path });
-                }
-            }
-        }
-
-        // Fall back to simple field assertion - but check if it's a range first
-        let expected_value: syn::Expr = input.parse()?;
-
-        // Check if it's a range expression
-        if matches!(expected_value, syn::Expr::Range(_)) {
-            return Ok(FieldAssertion::Range {
-                field_name,
-                range: expected_value,
-            });
-        }
-
-        Ok(FieldAssertion::Simple {
+        Ok(FieldAssertion {
             field_name,
-            expected_value,
+            pattern,
         })
-    }
-}
-
-// Parse the contents of a variant's tuple - handles special syntax like Some(> 30) or Foo(> 1, < 10)
-fn parse_variant_tuple_contents(input: ParseStream) -> Result<Vec<PatternElement>> {
-    // We need to look at the raw tokens to determine if there's special syntax
-    let content;
-    let _paren = syn::parenthesized!(content in input);
-
-    // Check if the content contains special syntax that requires special parsing
-    // Otherwise, treat it as a simple expression
-    let fork = content.fork();
-    let has_special_syntax = check_for_special_syntax(&fork);
-
-    if has_special_syntax {
-        // Parse all elements using the same logic as plain tuples
-        // This now supports comparison operators and regex in any position
-        parse_tuple_elements(&content)
-    } else {
-        // Parse as a single simple expression (could be a tuple literal, vec![], etc.)
-        let expr = content.parse()?;
-        Ok(vec![PatternElement::Simple(expr)])
     }
 }
 
@@ -305,174 +282,4 @@ fn check_for_special_syntax(content: ParseStream) -> bool {
     }
 
     false
-}
-
-// Parse the contents of a slice pattern [...]
-fn parse_slice_elements(content: ParseStream) -> Result<Vec<PatternElement>> {
-    // Similar to parse_tuple_elements but for slice patterns
-    // This allows comparison operators, regex, and nested patterns in slices
-    parse_pattern_elements(content)
-}
-
-// Parse the contents of a tuple pattern (for plain tuples without a variant)
-fn parse_tuple_elements(content: ParseStream) -> Result<Vec<PatternElement>> {
-    parse_pattern_elements(content)
-}
-
-// Common pattern element parsing used by both slices and tuples
-fn parse_pattern_elements(content: ParseStream) -> Result<Vec<PatternElement>> {
-    let mut elements = Vec::new();
-
-    while !content.is_empty() {
-        // Check for .. (rest pattern)
-        if content.peek(Token![..]) {
-            let _: Token![..] = content.parse()?;
-            elements.push(PatternElement::Rest);
-        }
-        // Check for brackets (slice pattern)
-        else if content.peek(syn::token::Bracket) {
-            // It's a slice pattern like [1, 2, 3]
-            let inner_content;
-            syn::bracketed!(inner_content in content);
-            let inner_elements = parse_pattern_elements(&inner_content)?;
-            // Create a SlicePattern element
-            elements.push(PatternElement::SlicePattern(inner_elements));
-        }
-        // Check for nested parentheses (nested tuple)
-        else if content.peek(syn::token::Paren) {
-            // It's a nested tuple like ((10, 20), ...)
-            let inner_content;
-            syn::parenthesized!(inner_content in content);
-            let inner_elements = parse_pattern_elements(&inner_content)?;
-            // Wrap in a TuplePattern without a path
-            elements.push(PatternElement::Tuple(None, inner_elements));
-        }
-        // Check for comparison operators
-        else if content.peek(Token![<]) || content.peek(Token![>]) {
-            // It's a comparison pattern
-            let op = if content.peek(Token![<]) {
-                let _: Token![<] = content.parse()?;
-                if content.peek(Token![=]) {
-                    let _: Token![=] = content.parse()?;
-                    ComparisonOp::LessEqual
-                } else {
-                    ComparisonOp::Less
-                }
-            } else {
-                let _: Token![>] = content.parse()?;
-                if content.peek(Token![=]) {
-                    let _: Token![=] = content.parse()?;
-                    ComparisonOp::GreaterEqual
-                } else {
-                    ComparisonOp::Greater
-                }
-            };
-
-            let value = content.parse()?;
-            elements.push(PatternElement::Comparison(op, value));
-        }
-        // Check for != operator
-        else if content.peek(Token![!]) {
-            let fork = content.fork();
-            if fork.parse::<Token![!]>().is_ok() && fork.peek(Token![=]) {
-                let _: Token![!] = content.parse()?;
-                let _: Token![=] = content.parse()?;
-                let value = content.parse()?;
-                elements.push(PatternElement::Comparison(ComparisonOp::NotEqual, value));
-            } else {
-                // Not a != operator, parse as regular expression
-                let expr = content.parse()?;
-                elements.push(PatternElement::Simple(expr));
-            }
-        }
-        // Check for == or =~ operators
-        else if content.peek(Token![=]) {
-            let fork = content.fork();
-            if fork.parse::<Token![=]>().is_ok() {
-                if fork.peek(Token![=]) {
-                    // == operator
-                    let _: Token![=] = content.parse()?;
-                    let _: Token![=] = content.parse()?;
-                    let value = content.parse()?;
-                    elements.push(PatternElement::Comparison(ComparisonOp::Equal, value));
-                } else if fork.peek(Token![~]) {
-                    // =~ regex operator
-                    #[cfg(feature = "regex")]
-                    {
-                        let _: Token![=] = content.parse()?;
-                        let _: Token![~] = content.parse()?;
-                        let lit: syn::LitStr = content.parse()?;
-                        elements.push(PatternElement::Regex(lit.value()));
-                    }
-                    #[cfg(not(feature = "regex"))]
-                    {
-                        // If regex feature is disabled, parse as regular expression
-                        let expr = content.parse()?;
-                        elements.push(PatternElement::Simple(expr));
-                    }
-                } else {
-                    // Just a single =, parse as regular expression
-                    let expr = content.parse()?;
-                    elements.push(PatternElement::Simple(expr));
-                }
-            } else {
-                // Not an operator, parse as regular expression
-                let expr = content.parse()?;
-                elements.push(PatternElement::Simple(expr));
-            }
-        }
-        // Try to parse as path (could be struct pattern or enum variant)
-        else {
-            let fork = content.fork();
-            if let Ok(path) = fork.parse::<syn::Path>() {
-                // Check if it's followed by braces (struct pattern)
-                if fork.peek(syn::token::Brace) {
-                    // It's a nested struct pattern
-                    let inner_path: syn::Path = content.parse()?;
-                    let inner_content;
-                    syn::braced!(inner_content in content);
-                    let inner_nested = inner_content.parse()?;
-
-                    elements.push(PatternElement::Struct(inner_path, inner_nested));
-                }
-                // Check if it's followed by parentheses (enum tuple variant like Some(...))
-                else if fork.peek(syn::token::Paren) {
-                    // It's an enum variant with tuple data
-                    let variant_path: syn::Path = content.parse()?;
-                    let variant_elements = parse_variant_tuple_contents(content)?;
-                    elements.push(PatternElement::Tuple(Some(variant_path), variant_elements));
-                } else {
-                    // It's either a unit variant or regular expression
-                    // Try to determine which by checking if it starts with uppercase
-                    if let Some(segment) = path.segments.last() {
-                        let name = segment.ident.to_string();
-                        if name.chars().next().is_some_and(|c| c.is_uppercase()) {
-                            // Likely a unit variant like None
-                            let variant_path: syn::Path = content.parse()?;
-                            elements.push(PatternElement::Tuple(Some(variant_path), vec![]));
-                        } else {
-                            // Regular expression
-                            let expr = content.parse()?;
-                            elements.push(PatternElement::Simple(expr));
-                        }
-                    } else {
-                        // Regular expression
-                        let expr = content.parse()?;
-                        elements.push(PatternElement::Simple(expr));
-                    }
-                }
-            } else {
-                // Regular expression
-                let expr = content.parse()?;
-                elements.push(PatternElement::Simple(expr));
-            }
-        }
-
-        // Handle comma
-        if !content.is_empty() {
-            let _: Token![,] = content.parse()?;
-        }
-    }
-
-    Ok(elements)
 }

--- a/tests/comparison.rs
+++ b/tests/comparison.rs
@@ -109,7 +109,7 @@ fn test_mixed_comparisons() {
 }
 
 #[test]
-#[should_panic(expected = "failed comparison")]
+#[should_panic(expected = "Failed comparison")]
 fn test_greater_than_failure() {
     let person = Person {
         name: "Frank".to_string(),
@@ -128,7 +128,7 @@ fn test_greater_than_failure() {
 }
 
 #[test]
-#[should_panic(expected = "failed comparison")]
+#[should_panic(expected = "Failed comparison")]
 fn test_less_than_failure() {
     let person = Person {
         name: "Grace".to_string(),

--- a/tests/compile_fail/type_mismatch.stderr
+++ b/tests/compile_fail/type_mismatch.stderr
@@ -1,14 +1,14 @@
-error[E0277]: can't compare `u32` with `&str`
+error[E0277]: can't compare `u32` with `String`
   --> tests/compile_fail/type_mismatch.rs:16:5
    |
 16 | /     assert_struct!(user, User {
 17 | |         name: "Alice",
 18 | |         age: "thirty",
 19 | |     });
-   | |______^ no implementation for `u32 == &str`
+   | |______^ no implementation for `u32 == String`
    |
-   = help: the trait `PartialEq<&str>` is not implemented for `u32`
+   = help: the trait `PartialEq<String>` is not implemented for `u32`
            but trait `PartialEq<u32>` is implemented for it
-   = help: for that trait implementation, expected `u32`, found `&str`
-   = note: required for `&u32` to implement `PartialEq<&&str>`
+   = help: for that trait implementation, expected `u32`, found `String`
+   = note: required for `&u32` to implement `PartialEq<&String>`
    = note: this error originates in the macro `assert_eq` which comes from the expansion of the macro `assert_struct` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/complex_expressions.rs
+++ b/tests/complex_expressions.rs
@@ -346,7 +346,7 @@ fn test_macro_in_expression() {
 
 // Test failure cases
 #[test]
-#[should_panic(expected = "Field `age` failed comparison")]
+#[should_panic(expected = "Failed comparison")]
 fn test_complex_expression_failure() {
     let user = User {
         name: "Mike".to_string(),

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -371,7 +371,7 @@ fn test_nested_enum_struct_variant() {
 
 // Failure tests
 #[test]
-#[should_panic(expected = "expected Ok, got Err")]
+#[should_panic(expected = "Expected Ok, got Err")]
 fn test_result_expected_ok_got_err() {
     let data = UserData {
         login_result: Err("Failed".to_string()),
@@ -396,7 +396,7 @@ fn test_result_expected_ok_got_err() {
 }
 
 #[test]
-#[should_panic(expected = "expected Status :: Active, got")]
+#[should_panic(expected = "Expected Status :: Active, got")]
 fn test_enum_variant_mismatch() {
     let account = Account {
         id: 5,

--- a/tests/equality.rs
+++ b/tests/equality.rs
@@ -101,7 +101,7 @@ fn test_equality_in_tuples() {
 
 // Test failure cases
 #[test]
-#[should_panic(expected = "Field `name` failed equality")]
+#[should_panic(expected = "Failed equality")]
 fn test_equality_failure() {
     let user = User {
         name: "Alice".to_string(),
@@ -117,7 +117,7 @@ fn test_equality_failure() {
 }
 
 #[test]
-#[should_panic(expected = "Field `age` failed inequality")]
+#[should_panic(expected = "Failed inequality")]
 fn test_inequality_failure() {
     let user = User {
         name: "Alice".to_string(),

--- a/tests/equality_struct.rs
+++ b/tests/equality_struct.rs
@@ -111,7 +111,7 @@ fn test_nested_struct_equality() {
 
 // Test failure cases
 #[test]
-#[should_panic(expected = "Field `origin` failed equality")]
+#[should_panic(expected = "Failed equality")]
 fn test_struct_equality_failure() {
     let shape = Shape {
         origin: Point { x: 0, y: 0 },
@@ -125,7 +125,7 @@ fn test_struct_equality_failure() {
 }
 
 #[test]
-#[should_panic(expected = "Field `center` failed inequality")]
+#[should_panic(expected = "Failed inequality")]
 fn test_struct_inequality_failure() {
     let shape = Shape {
         origin: Point { x: 0, y: 0 },

--- a/tests/non_struct_root.rs
+++ b/tests/non_struct_root.rs
@@ -1,0 +1,129 @@
+use assert_struct::assert_struct;
+
+#[test]
+fn test_range_at_root() {
+    let value = 15;
+    assert_struct!(value, 10..20);
+}
+
+#[test]
+fn test_comparison_at_root() {
+    let value = 25;
+    assert_struct!(value, > 20);
+    assert_struct!(value, <= 30);
+    assert_struct!(value, == 25);
+}
+
+#[test]
+fn test_option_at_root() {
+    let value = Some(42);
+    assert_struct!(value, Some(42));
+
+    let none_value: Option<i32> = None;
+    assert_struct!(none_value, None);
+}
+
+#[test]
+fn test_option_with_comparison_at_root() {
+    let value = Some(50);
+    assert_struct!(value, Some(> 40));
+}
+
+#[test]
+fn test_option_slice_at_root() {
+    let data = Some(vec![1, 2, 3]);
+    assert_struct!(data, Some([1, 2, 3]));
+
+    let data = Some(vec![1, 2, 3, 4, 5]);
+    assert_struct!(data, Some([1, 2, ..]));
+}
+
+#[test]
+fn test_slice_at_root() {
+    let items = vec![1, 2, 3];
+    assert_struct!(items, [1, 2, 3]);
+
+    let items = vec![10, 20, 30, 40];
+    assert_struct!(items, [10, 20, ..]);
+    assert_struct!(items, [.., 40]);
+}
+
+#[test]
+fn test_slice_with_comparisons_at_root() {
+    let items = vec![5, 15, 25];
+    assert_struct!(items, [> 0, < 20, == 25]);
+}
+
+#[test]
+fn test_tuple_at_root() {
+    let pair = (10, 20);
+    assert_struct!(pair, (10, 20));
+
+    let triple = (1, "hello", true);
+    assert_struct!(triple, (1, "hello", true));
+}
+
+#[test]
+fn test_tuple_with_comparisons_at_root() {
+    let pair = (15, 25);
+    assert_struct!(pair, (> 10, < 30));
+}
+
+#[test]
+fn test_result_at_root() {
+    let result: Result<i32, String> = Ok(42);
+    assert_struct!(result, Ok(42));
+
+    let error: Result<i32, String> = Err("error".to_string());
+    assert_struct!(error, Err("error"));
+}
+
+#[test]
+fn test_result_with_slice_at_root() {
+    let result: Result<Vec<i32>, String> = Ok(vec![1, 2, 3]);
+    assert_struct!(result, Ok([1, 2, 3]));
+}
+
+#[test]
+fn test_nested_pattern_at_root() {
+    // Simple nested patterns work
+    let simple = Some((10, 20));
+    assert_struct!(simple, Some((10, 20)));
+
+    // Complex nested patterns with slices need workaround for now
+    // let complex = Some((10, vec![1, 2, 3], "test"));
+    // assert_struct!(complex, Some((10, [1, 2, 3], "test")));
+}
+
+#[test]
+#[cfg(feature = "regex")]
+fn test_regex_at_root() {
+    let text = "hello123";
+    assert_struct!(text, =~ r"^hello\d+$");
+}
+
+#[test]
+fn test_simple_value_at_root() {
+    let value = 42;
+    assert_struct!(value, 42);
+
+    let text = "hello";
+    assert_struct!(text, "hello");
+
+    let flag = true;
+    assert_struct!(flag, true);
+}
+
+// Test that we can still do struct patterns
+#[derive(Debug)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[test]
+fn test_struct_still_works() {
+    let point = Point { x: 10, y: 20 };
+    assert_struct!(point, Point { x: 10, y: 20 });
+    assert_struct!(point, Point { x: > 5, .. });
+}

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -200,7 +200,7 @@ fn test_option_none_with_collections() {
 // Failure cases
 
 #[test]
-#[should_panic(expected = "expected None, got Some")]
+#[should_panic(expected = "Expected None, got Some")]
 fn test_some_none_mismatch() {
     let user = User {
         id: 7,
@@ -223,7 +223,7 @@ fn test_some_none_mismatch() {
 }
 
 #[test]
-#[should_panic(expected = "expected Some(...), got None")]
+#[should_panic(expected = "Expected Some(...), got None")]
 fn test_none_some_mismatch() {
     let user = User {
         id: 8,

--- a/tests/option_advanced.rs
+++ b/tests/option_advanced.rs
@@ -127,7 +127,7 @@ fn test_mixed_option_patterns() {
 // Failure tests
 
 #[test]
-#[should_panic(expected = "failed comparison")]
+#[should_panic(expected = "Failed comparison")]
 fn test_option_comparison_failure() {
     let user = User {
         name: "Grace".to_string(),
@@ -145,7 +145,7 @@ fn test_option_comparison_failure() {
 }
 
 #[test]
-#[should_panic(expected = "expected Some(...), got None")]
+#[should_panic(expected = "Expected Some(...), got None")]
 fn test_option_comparison_none_failure() {
     let user = User {
         name: "Henry".to_string(),

--- a/tests/option_nested.rs
+++ b/tests/option_nested.rs
@@ -164,7 +164,7 @@ fn test_nested_field_mismatch() {
 }
 
 #[test]
-#[should_panic(expected = "expected Some(...), got None")]
+#[should_panic(expected = "Expected Some(...), got None")]
 fn test_expected_some_got_none_nested() {
     let profile = Profile {
         bio: Some("Developer".to_string()),

--- a/tests/ranges.rs
+++ b/tests/ranges.rs
@@ -179,7 +179,7 @@ fn test_mixed_range_and_operators() {
 
 // Test failure cases
 #[test]
-#[should_panic(expected = "Field `age` not in range")]
+#[should_panic(expected = "Value not in range")]
 fn test_range_failure_below() {
     let person = Person {
         name: "Too Young".to_string(),
@@ -199,7 +199,7 @@ fn test_range_failure_below() {
 }
 
 #[test]
-#[should_panic(expected = "Field `age` not in range")]
+#[should_panic(expected = "Value not in range")]
 fn test_range_failure_above() {
     let person = Person {
         name: "Too Old".to_string(),
@@ -219,7 +219,7 @@ fn test_range_failure_above() {
 }
 
 #[test]
-#[should_panic(expected = "Field `score` not in range")]
+#[should_panic(expected = "Value not in range")]
 fn test_range_exclusive_boundary_failure() {
     let person = Person {
         name: "Boundary".to_string(),

--- a/tests/slices.rs
+++ b/tests/slices.rs
@@ -163,7 +163,7 @@ fn test_empty_slice() {
 }
 
 #[test]
-#[should_panic(expected = "pattern mismatch")]
+#[should_panic(expected = "Pattern mismatch")]
 fn test_slice_length_mismatch() {
     let container = Container {
         items: vec![1, 2, 3],

--- a/tests/test_range_expansion.rs
+++ b/tests/test_range_expansion.rs
@@ -23,7 +23,7 @@ fn test_range() {
 }
 
 #[test]
-#[should_panic(expected = "Field `age` not in range")]
+#[should_panic(expected = "Value not in range")]
 fn test_range_failure() {
     let person = Person {
         age: 70,

--- a/tests/tuples.rs
+++ b/tests/tuples.rs
@@ -232,7 +232,7 @@ fn test_tuple_field_mismatch() {
 }
 
 #[test]
-#[should_panic(expected = "Element failed comparison")]
+#[should_panic(expected = "Failed comparison")]
 fn test_tuple_comparison_failure() {
     let coords = Coordinates {
         point2d: (5, 20),


### PR DESCRIPTION
## Summary

This PR generalizes the `assert_struct` macro to accept any pattern at the root level, not just structs. This enables more flexible and ergonomic assertions.

## New Capabilities

The macro now supports patterns like:
- `assert_struct!(value, 10..20)` - range patterns at root
- `assert_struct!(data, Some([1, 2, 3]))` - Option with slice at root  
- `assert_struct!(items, [1, 2, 3])` - slice patterns at root
- `assert_struct!(value, > 30)` - comparison operators at root
- `assert_struct!(text, =~ r"pattern")` - regex patterns at root (with feature)

## Implementation Details

### Unified Pattern System
- Replaced the old AST structure with a unified `Pattern` enum
- Simplified `FieldAssertion` to just contain field_name and pattern
- Created a single recursive pattern type that can represent any assertion pattern

### Simplified Code Generation
- Created a single recursive `generate_pattern_assertion` function
- Eliminated code duplication by leveraging cleaner recursion
- Proper reference handling with `is_ref` tracking

### Bug Fixes
- Fixed enum struct variants (like `Status::Pending { since: String }`) to generate match expressions instead of let bindings
- Updated all test error message expectations

## Test Coverage

Added comprehensive tests in `tests/non_struct_root.rs` demonstrating all new root-level pattern capabilities. All existing tests pass with updated error message expectations.

## Breaking Changes

Error messages have changed from field-specific messages (e.g., "Field \`age\` not in range") to more general messages (e.g., "Value not in range"). This is a minor breaking change for tests that depend on specific panic message text.