### PR TITLE
Add field operations support with dereferencing

### DIFF
--- a/assert-struct-macros/src/expand.rs
+++ b/assert-struct-macros/src/expand.rs
@@ -1,4 +1,4 @@
-use crate::{AssertStruct, ComparisonOp, FieldAssertion, Pattern};
+use crate::{AssertStruct, ComparisonOp, FieldAssertion, FieldOperation, Pattern, TupleElement};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned};
 use syn::{Expr, Token, punctuated::Punctuated, spanned::Spanned};
@@ -193,7 +193,13 @@ fn generate_pattern_nodes(
         Pattern::Tuple { path, elements, .. } => {
             let child_refs: Vec<TokenStream> = elements
                 .iter()
-                .map(|elem| generate_pattern_nodes(elem, node_defs))
+                .map(|elem| {
+                    let pattern = match elem {
+                        TupleElement::Positional { pattern } => pattern,
+                        TupleElement::Indexed { pattern, .. } => pattern,
+                    };
+                    generate_pattern_nodes(pattern, node_defs)
+                })
                 .collect();
 
             if let Some(enum_path) = path {
@@ -451,14 +457,54 @@ fn generate_struct_match_assertion_with_collection(
         .map(|f| {
             let field_name = &f.field_name;
             let field_pattern = &f.pattern;
-            // Build path for this field
+            let field_operations = &f.operations;
+            
+            // Build path for this field - include operations if present
             let mut new_path = field_path.to_vec();
-            new_path.push(field_name.to_string());
-            // Fields from destructuring are references
+            let field_path_str = if let Some(ops) = field_operations {
+                // Include operation in path for better error messages
+                match ops {
+                    FieldOperation::Deref { count } => {
+                        let stars = "*".repeat(*count);
+                        format!("{}{}", stars, field_name)
+                    }
+                    FieldOperation::Method { name, .. } => {
+                        format!("{}.{}()", field_name, name)
+                    }
+                    FieldOperation::Nested { fields } => {
+                        let nested = fields.iter().map(|f| f.to_string()).collect::<Vec<_>>().join(".");
+                        format!("{}.{}", field_name, nested)
+                    }
+                    FieldOperation::Combined { deref_count, operation } => {
+                        let stars = "*".repeat(*deref_count);
+                        format!("{}{}{}", stars, field_name, operation)
+                    }
+                }
+            } else {
+                field_name.to_string()
+            };
+            new_path.push(field_path_str);
+            
+            // Generate the value expression with operations applied
+            let (value_expr, is_ref_after_operations) = if let Some(ops) = field_operations {
+                // We're always in a reference context for struct destructuring (match &value)
+                let expr = apply_field_operations(&quote! { #field_name }, ops, true);
+                // Dereferencing operations change the reference level
+                let is_ref = match ops {
+                    FieldOperation::Deref { .. } => false, // Dereferencing removes reference level
+                    FieldOperation::Combined { .. } => false, // Combined with deref also removes reference level
+                    _ => true, // Other operations keep reference level
+                };
+                (expr, is_ref)
+            } else {
+                (quote! { #field_name }, true)
+            };
+            
+            // Generate assertion with appropriate reference handling
             let assertion = generate_pattern_assertion_with_collection(
-                &quote! { #field_name },
+                &value_expr,
                 field_pattern,
-                true,
+                is_ref_after_operations,
                 &new_path,
             );
 
@@ -529,25 +575,70 @@ fn generate_struct_match_assertion_with_collection(
     }
 }
 
-/// Helper function to process tuple/slice elements and generate match patterns and assertions.
+/// Apply field operations to a value expression
+/// This generates the appropriate dereferencing, method calls, or nested field access
+/// 
+/// # Parameters
+/// - `base_expr`: The base expression to apply operations to
+/// - `operation`: The field operation to apply
+/// - `in_ref_context`: Whether we're in a reference context (from destructuring `&value`)
+fn apply_field_operations(base_expr: &TokenStream, operation: &FieldOperation, in_ref_context: bool) -> TokenStream {
+    match operation {
+        FieldOperation::Deref { count } => {
+            let mut expr = base_expr.clone();
+            // In reference context, we need one extra dereference
+            let total_count = if in_ref_context { count + 1 } else { *count };
+            for _ in 0..total_count {
+                expr = quote! { *#expr };
+            }
+            expr
+        }
+        FieldOperation::Method { name, args } => {
+            if args.is_empty() {
+                quote! { #base_expr.#name() }
+            } else {
+                quote! { #base_expr.#name(#(#args),*) }
+            }
+        }
+        FieldOperation::Nested { fields } => {
+            let mut expr = base_expr.clone();
+            for field in fields {
+                expr = quote! { #expr.#field };
+            }
+            expr
+        }
+        FieldOperation::Combined { deref_count, operation } => {
+            // First apply dereferencing with reference context awareness
+            let mut expr = base_expr.clone();
+            let total_count = if in_ref_context { deref_count + 1 } else { *deref_count };
+            for _ in 0..total_count {
+                expr = quote! { *#expr };
+            }
+            // Then apply the nested operation (no longer in ref context after deref)
+            apply_field_operations(&expr, operation, false)
+        }
+    }
+}
+
+/// Helper function to process tuple elements and generate match patterns and assertions.
 ///
 /// This function handles the common pattern of iterating through elements and:
 /// - Creating `_` patterns for wildcards (which need no assertions)
 /// - Creating named bindings for other patterns and generating their assertions
+/// - Handling field operations like dereferencing
 ///
 /// # Parameters
-/// - `elements`: The patterns to process
+/// - `elements`: The tuple elements to process (can be positional or indexed)
 /// - `prefix`: Prefix for generated binding names (e.g., "__elem_", "__tuple_elem_")
 /// - `is_ref`: Whether the bindings are already references
 /// - `field_path`: Path components for error messages
-/// - `use_collection`: Whether to use error collection or immediate panics
 ///
 /// # Returns
 /// A tuple of (match_patterns, assertions) where:
 /// - `match_patterns`: TokenStreams for use in match arms or destructuring
 /// - `assertions`: TokenStreams for the generated assertion code
 fn process_tuple_elements(
-    elements: &[Pattern],
+    elements: &[TupleElement],
     prefix: &str,
     is_ref: bool,
     field_path: &[String],
@@ -555,7 +646,12 @@ fn process_tuple_elements(
     let mut match_patterns = Vec::new();
     let mut assertions = Vec::new();
 
-    for (i, pattern) in elements.iter().enumerate() {
+    for (i, tuple_element) in elements.iter().enumerate() {
+        let (pattern, operations) = match tuple_element {
+            TupleElement::Positional { pattern } => (pattern, &None),
+            TupleElement::Indexed { pattern, operations, .. } => (pattern, operations),
+        };
+
         match pattern {
             Pattern::Wildcard { .. } => {
                 // Wildcard patterns use `_` in the match pattern.
@@ -568,15 +664,56 @@ fn process_tuple_elements(
                 let name = quote::format_ident!("{}{}", prefix, i);
                 match_patterns.push(quote! { #name });
 
-                // Build path for error messages
+                // Build path for error messages - include operations if present
                 let mut elem_path = field_path.to_vec();
-                elem_path.push(i.to_string());
+                let elem_path_str = if let Some(ops) = operations {
+                    // Include operation in path for better error messages
+                    match ops {
+                        FieldOperation::Deref { count } => {
+                            let stars = "*".repeat(*count);
+                            format!("{}{}", stars, i)
+                        }
+                        FieldOperation::Method { name, .. } => {
+                            format!("{}.{}()", i, name)
+                        }
+                        FieldOperation::Nested { fields } => {
+                            let nested = fields.iter().map(|f| f.to_string()).collect::<Vec<_>>().join(".");
+                            format!("{}.{}", i, nested)
+                        }
+                        FieldOperation::Combined { deref_count, operation } => {
+                            let stars = "*".repeat(*deref_count);
+                            format!("{}{}{}", stars, i, operation)
+                        }
+                    }
+                } else {
+                    i.to_string()
+                };
+                elem_path.push(elem_path_str);
+
+                // Generate the value expression with operations applied
+                let value_expr = if let Some(ops) = operations {
+                    // Tuple elements are in reference context when destructured
+                    apply_field_operations(&quote! { #name }, ops, true)
+                } else {
+                    quote! { #name }
+                };
+
+                // Apply the same reference level logic as for struct fields
+                let is_ref_after_operations = if operations.is_some() {
+                    match operations.as_ref().unwrap() {
+                        FieldOperation::Deref { .. } => false, // Dereferencing removes reference level
+                        FieldOperation::Combined { .. } => false, // Combined with deref also removes reference level
+                        _ => is_ref, // Other operations keep reference level
+                    }
+                } else {
+                    is_ref
+                };
 
                 // Generate assertion with error collection
                 let assertion = generate_pattern_assertion_with_collection(
-                    &quote! { #name },
+                    &value_expr,
                     pattern,
-                    is_ref,
+                    is_ref_after_operations,
                     &elem_path,
                 );
                 assertions.push(assertion);
@@ -591,7 +728,7 @@ fn process_tuple_elements(
 /// Uses match expressions for consistency with enum tuple handling.
 fn generate_plain_tuple_assertion_with_collection(
     value_expr: &TokenStream,
-    elements: &[Pattern],
+    elements: &[TupleElement],
     is_ref: bool,
     field_path: &[String],
     _node_ident: &Ident,
@@ -774,7 +911,7 @@ fn generate_comparison_assertion_with_collection(
 fn generate_enum_tuple_assertion_with_collection(
     value_expr: &TokenStream,
     variant_path: &syn::Path,
-    elements: &[Pattern],
+    elements: &[TupleElement],
     is_ref: bool,
     field_path: &[String],
     node_ident: &Ident,

--- a/assert-struct-macros/src/parse.rs
+++ b/assert-struct-macros/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::{AssertStruct, ComparisonOp, Expected, FieldAssertion, Pattern};
+use crate::{AssertStruct, ComparisonOp, Expected, FieldAssertion, FieldOperation, Pattern, TupleElement};
 use std::cell::Cell;
 use syn::{Result, Token, parse::Parse, parse::ParseStream, punctuated::Punctuated};
 
@@ -278,7 +278,7 @@ fn parse_pattern(input: ParseStream) -> Result<Pattern> {
         if has_special {
             // Contains pattern syntax like `>`, `==`, nested patterns
             // Example: `(> 10, < 30)`, `(== 5, != 10)`
-            let elements = parse_pattern_list(&content)?;
+            let elements = parse_tuple_elements(&content)?;
             return Ok(Pattern::Tuple {
                 node_id: next_node_id(),
                 path: None,
@@ -331,7 +331,7 @@ fn parse_pattern(input: ParseStream) -> Result<Pattern> {
             if has_special {
                 // Contains pattern syntax like `>`, `==`, nested patterns
                 // Example: `Some(> 30)`, `Event::Click(>= 0, < 100)`
-                let elements = parse_pattern_list(&content)?;
+                let elements = parse_tuple_elements(&content)?;
                 return Ok(Pattern::Tuple {
                     node_id: next_node_id(),
                     path: Some(path),
@@ -345,9 +345,11 @@ fn parse_pattern(input: ParseStream) -> Result<Pattern> {
                 return Ok(Pattern::Tuple {
                     node_id: next_node_id(),
                     path: Some(path),
-                    elements: vec![Pattern::Simple {
-                        node_id: next_node_id(),
-                        expr,
+                    elements: vec![TupleElement::Positional {
+                        pattern: Pattern::Simple {
+                            node_id: next_node_id(),
+                            expr,
+                        },
                     }],
                 });
             }
@@ -404,6 +406,88 @@ fn parse_pattern_list(input: ParseStream) -> Result<Vec<Pattern>> {
     Ok(patterns)
 }
 
+/// Parse operations for tuple elements (currently just dereferencing)
+/// This is simpler than field operations since we only support * for now
+fn parse_element_operations(input: ParseStream) -> Result<Option<FieldOperation>> {
+    let mut deref_count = 0;
+    
+    // Count leading * tokens for dereferencing
+    while input.peek(Token![*]) {
+        let _: Token![*] = input.parse()?;
+        deref_count += 1;
+    }
+    
+    if deref_count > 0 {
+        Ok(Some(FieldOperation::Deref { count: deref_count }))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Parse a comma-separated list of tuple elements, supporting both positional and indexed syntax.
+/// Used inside tuple patterns to handle mixed syntax like ("foo", *1: "bar", "baz")
+fn parse_tuple_elements(input: ParseStream) -> Result<Vec<TupleElement>> {
+    let mut elements = Vec::new();
+    let mut position = 0;
+
+    while !input.is_empty() {
+        // First, try to parse operations (like * for deref)
+        let operations = parse_element_operations(input)?;
+        
+        // Check if this is an indexed element by looking for number followed by colon
+        let fork = input.fork();
+        let is_indexed = if let Ok(_index_lit) = fork.parse::<syn::LitInt>() {
+            fork.peek(Token![:])
+        } else {
+            false
+        };
+
+        if is_indexed {
+            // Parse indexed element: index: pattern or *index: pattern
+            let index_lit: syn::LitInt = input.parse()?;
+            let index: usize = index_lit.base10_parse()?;
+            
+            // Validate that index matches current position
+            if index != position {
+                return Err(syn::Error::new_spanned(
+                    index_lit,
+                    format!("Index {} must match position {} in tuple", index, position),
+                ));
+            }
+            
+            let _: Token![:] = input.parse()?;
+            let pattern = parse_pattern(input)?;
+            
+            elements.push(TupleElement::Indexed {
+                index,
+                operations,
+                pattern,
+            });
+        } else {
+            // If we parsed operations but no index, this is an error
+            if operations.is_some() {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "Operations like * can only be used with indexed elements (e.g., *0:, *1:)",
+                ));
+            }
+            
+            // Parse positional element: just a pattern
+            let pattern = parse_pattern(input)?;
+            elements.push(TupleElement::Positional { pattern });
+        }
+        
+        position += 1;
+
+        if !input.is_empty() {
+            let _: Token![,] = input.parse()?;
+        }
+    }
+
+    Ok(elements)
+}
+
+
 impl Parse for FieldAssertion {
     /// Parses a single field assertion within a struct pattern.
     ///
@@ -411,15 +495,37 @@ impl Parse for FieldAssertion {
     /// ```text
     /// name: "Alice"
     /// age: >= 18
+    /// *boxed_value: 42
     /// email: =~ r".*@example\.com"
     /// ```
     fn parse(input: ParseStream) -> Result<Self> {
+        // Check if we have field operations (starting with * for deref)
+        let mut operations = None;
+        let mut deref_count = 0;
+        
+        // Count leading * tokens for dereferencing
+        while input.peek(Token![*]) {
+            let _: Token![*] = input.parse()?;
+            deref_count += 1;
+        }
+        
+        if deref_count > 0 {
+            operations = Some(FieldOperation::Deref { count: deref_count });
+            // Debug: Add a compile error to verify parsing is working
+            // return Err(syn::Error::new(input.span(), format!("DEBUG: Found {} deref operations", deref_count)));
+        }
+        
         let field_name: syn::Ident = input.parse()?;
+        
+        // TODO: Handle method calls and nested field access after the field name
+        // This would involve looking for patterns like field.method() or field.nested
+        
         let _: Token![:] = input.parse()?;
         let pattern = parse_pattern(input)?;
 
         Ok(FieldAssertion {
             field_name,
+            operations,
             pattern,
         })
     }

--- a/assert-struct/tests/auto_deref_simple.rs
+++ b/assert-struct/tests/auto_deref_simple.rs
@@ -1,0 +1,32 @@
+// Start with a simple auto-deref test case
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct SimpleBox {
+    boxed_option: Box<Option<i32>>,
+}
+
+#[test]
+fn test_box_option_with_closure() {
+    let test = SimpleBox {
+        boxed_option: Box::new(Some(42)),
+    };
+
+    // This currently works with closures
+    assert_struct!(test, SimpleBox {
+        boxed_option: |b| matches!(**b, Some(42)),
+    });
+}
+
+// TODO: Enable once auto-deref is implemented
+// #[test]
+// fn test_box_option_auto_deref() {
+//     let test = SimpleBox {
+//         boxed_option: Box::new(Some(42)),
+//     };
+//
+//     // Test auto-deref: Box<Option<i32>> -> Option<i32>
+//     assert_struct!(test, SimpleBox {
+//         boxed_option: Some(42),  // Should auto-deref Box<Option<i32>> -> Option<i32>
+//     });
+// }

--- a/assert-struct/tests/field_operations.rs
+++ b/assert-struct/tests/field_operations.rs
@@ -1,0 +1,66 @@
+// Test field operations like dereferencing, method calls, and nested access
+
+use assert_struct::assert_struct;
+use std::rc::Rc;
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct TestStruct {
+    boxed_value: Box<i32>,
+    rc_value: Rc<String>,
+    arc_value: Arc<u32>,
+    tuple_with_box: (String, Box<i32>),
+    normal_value: i32,
+}
+
+#[test]
+fn test_deref_simple() {
+    let test = TestStruct {
+        boxed_value: Box::new(42),
+        rc_value: Rc::new("hello".to_string()),
+        arc_value: Arc::new(100),
+        tuple_with_box: ("test".to_string(), Box::new(99)),
+        normal_value: 200,
+    };
+
+    // Test basic dereferencing  
+    assert_struct!(test, TestStruct {
+        normal_value: 200,
+        *boxed_value: 42,
+        ..
+    });
+}
+
+#[test]
+fn test_tuple_indexed_deref() {
+    let test = TestStruct {
+        boxed_value: Box::new(42),
+        rc_value: Rc::new("hello".to_string()),
+        arc_value: Arc::new(100),
+        tuple_with_box: ("test".to_string(), Box::new(99)),
+        normal_value: 200,
+    };
+
+    // Test tuple with indexed dereferencing
+    assert_struct!(test, TestStruct {
+        tuple_with_box: ("test", *1: 99),
+        ..
+    });
+}
+
+#[test]
+fn test_mixed_tuple_syntax() {
+    let test = TestStruct {
+        boxed_value: Box::new(42),
+        rc_value: Rc::new("hello".to_string()),
+        arc_value: Arc::new(100),
+        tuple_with_box: ("test".to_string(), Box::new(99)),
+        normal_value: 200,
+    };
+
+    // Test mixed positional and indexed syntax
+    assert_struct!(test, TestStruct {
+        tuple_with_box: ("test", *1: 99),  // Mixed: positional + indexed with deref
+        ..
+    });
+}

--- a/assert-struct/tests/macro_expansion_debug.rs
+++ b/assert-struct/tests/macro_expansion_debug.rs
@@ -1,0 +1,17 @@
+// Test to understand current macro expansion
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Simple {
+    value: i32,
+}
+
+#[test]
+fn test_simple_expansion() {
+    let s = Simple { value: 42 };
+    
+    // Simple case to see how the macro expands
+    assert_struct!(s, Simple {
+        value: 42,
+    });
+}

--- a/assert-struct/tests/test_box_deref.rs
+++ b/assert-struct/tests/test_box_deref.rs
@@ -1,0 +1,76 @@
+// Test current behavior with Box fields and plan for auto-deref implementation
+
+use assert_struct::assert_struct;
+use std::rc::Rc;
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct TestStruct {
+    boxed_value: Box<Option<i32>>,
+    rc_value: Rc<String>,
+    arc_value: Arc<u32>,
+    normal_value: i32,
+}
+
+#[test]
+fn test_current_box_behavior() {
+    let test = TestStruct {
+        boxed_value: Box::new(Some(42)),
+        rc_value: Rc::new("hello".to_string()),
+        arc_value: Arc::new(100),
+        normal_value: 200,
+    };
+
+    // This currently works - normal value
+    assert_struct!(test, TestStruct {
+        normal_value: 200,
+        ..
+    });
+
+    // This currently requires closures for Box/Rc/Arc
+    assert_struct!(test, TestStruct {
+        boxed_value: |b| matches!(**b, Some(42)),
+        rc_value: |s| s.as_str() == "hello",
+        arc_value: |a| **a == 100,
+        normal_value: 200,
+        ..
+    });
+}
+
+// TODO: These tests will be enabled once auto-deref is implemented
+// 
+// #[test]
+// fn test_auto_deref_goal() {
+//     let test = TestStruct {
+//         boxed_value: Box::new(Some(42)),
+//         rc_value: Rc::new("hello".to_string()),
+//         arc_value: Arc::new(100),
+//         normal_value: 200,
+//     };
+//
+//     // This is what we want to achieve with auto-deref:
+//     assert_struct!(test, TestStruct {
+//         boxed_value: Some(42),      // Auto-deref Box<Option<i32>> -> Option<i32>
+//         rc_value: "hello",          // Auto-deref Rc<String> -> String
+//         arc_value: 100,             // Auto-deref Arc<u32> -> u32
+//         normal_value: 200,          // No deref needed
+//         ..
+//     });
+// }
+//
+// #[test]
+// fn test_nested_smart_pointers_goal() {
+//     #[derive(Debug)]
+//     struct NestedStruct {
+//         complex: Box<Rc<Option<String>>>,
+//     }
+//
+//     let nested = NestedStruct {
+//         complex: Box::new(Rc::new(Some("test".to_string()))),
+//     };
+//
+//     // Goal: Handle nested smart pointers automatically
+//     assert_struct!(nested, NestedStruct {
+//         complex: Some("test"),  // Auto-deref Box<Rc<Option<String>>> -> Option<String>
+//     });
+// }

--- a/docs/design/box-deref-patterns.md
+++ b/docs/design/box-deref-patterns.md
@@ -1,0 +1,391 @@
+# Auto-Deref Pattern Matching Design
+
+## Overview
+
+This document outlines the design for automatic dereferencing in `assert_struct!` patterns. This feature will allow transparent pattern matching through any type that implements `Deref`, including `Box<T>`, `Rc<T>`, `Arc<T>`, and custom smart pointers.
+
+## Problem Statement
+
+In AST parsing and other complex data structures, smart pointers are commonly used. Currently, users must either:
+
+1. Use closure escape hatch for dereferencing  
+2. Write separate assertions outside of `assert_struct!`
+
+```rust
+// Current workarounds:
+assert_struct!(node, AstNode {
+    // Option 1: Verbose closure
+    expr: |boxed| matches!(**boxed, Expr::Literal(_)),
+    
+    // Option 2: Separate assertion (outside assert_struct)
+    ..
+});
+assert!(matches!(**node.expr, Expr::Literal(_)));
+```
+
+## Key Insight: Rust's Match Behavior
+
+**Critical Discovery**: Rust's `match` statements do NOT auto-dereference smart pointers:
+
+```rust
+let boxed: Box<Option<u32>> = Box::new(Some(42));
+
+// ❌ This fails - no auto-deref through Box
+match boxed {
+    Some(x) => ...,  // Type error!
+}
+
+// ✅ This works - explicit deref
+match *boxed {
+    Some(x) => ...,  // Success!
+}
+```
+
+## Proposed Solution
+
+**Generate appropriate `*` operators** instead of special syntax:
+
+```rust
+// User writes natural patterns:
+assert_struct!(node, AstNode {
+    expr: Expr::Literal {
+        value: > 0,
+        ..
+    },
+    // Works with any Deref type!
+    ..
+});
+
+// Macro detects field is Box<Expr> but pattern expects Expr
+// Generates: match *node.expr { Expr::Literal { value, .. } => ... }
+```
+
+## Design Principles
+
+1. **No Special Syntax**: Users write natural patterns, macro handles dereferencing
+2. **Universal Deref Support**: Works with ANY type implementing `Deref`
+3. **Type-Driven**: Let Rust's type system guide when dereferencing is needed
+4. **Zero Runtime Cost**: Just generates `*` operators, no wrapper logic
+5. **Composability**: Works with all existing patterns seamlessly
+
+## How It Works
+
+### Type-Driven Deref Detection
+
+The macro analyzes the **field type** vs **pattern expectation**:
+
+```rust
+struct AstNode {
+    expr: Box<Expr>,        // Field type: Box<Expr>
+    maybe: Option<Rc<Data>>, // Field type: Option<Rc<Data>>
+}
+
+assert_struct!(node, AstNode {
+    expr: Expr::Literal { .. },    // Pattern expects: Expr
+    maybe: Some(Data { .. }),       // Pattern expects: Option<Data>
+});
+```
+
+### Deref Chain Calculation
+
+The macro calculates the "deref distance":
+
+- `Box<Expr>` → `Expr` = 1 deref (`*field`)
+- `Rc<Option<T>>` → `Option<T>` = 1 deref (`*field`) 
+- `Arc<Box<T>>` → `T` = 2 derefs (`**field`)
+
+### Integration with Existing Patterns
+
+Auto-deref works transparently with ALL existing patterns:
+
+```rust
+assert_struct!(data, DataStruct {
+    // With comparisons - Box<i32> auto-derefs to i32
+    boxed_num: > 42,
+    
+    // With ranges - Box<u32> auto-derefs to u32  
+    boxed_age: 18..=65,
+    
+    // With regex - Box<String> auto-derefs to String
+    boxed_name: =~ r"^[A-Z][a-z]+$",
+    
+    // With wildcards - Rc<Option<T>> auto-derefs to Option<T>
+    maybe_boxed: Some(_),
+    
+    // With structs - Box<User> auto-derefs to User
+    boxed_user: User {
+        name: "Alice",
+        age: > 18,
+        ..
+    },
+    
+    // With enums - Arc<Result<T,E>> auto-derefs to Result<T,E>
+    boxed_result: Ok {
+        value: > 0,
+        ..
+    },
+    
+    // With tuples - Box<(i32,i32)> auto-derefs to (i32,i32)
+    boxed_point: (> 0, < 100),
+    
+    // With slices/vectors - Box<Vec<T>> auto-derefs to Vec<T>
+    boxed_vec: [1, 2, 3],
+    
+    // Nested smart pointers - Box<Rc<Option<String>>> auto-derefs as needed
+    nested: Some("hello"),  // Box<Rc<Option<String>>> -> Option<String>
+    
+    // With closures (escape hatch still works)
+    complex: |inner| inner.custom_validation(),  // Deref happens before closure
+});
+
+// Generated code examples:
+// boxed_num: > 42        → match *data.boxed_num { x if x > 42 => ... }
+// boxed_user: User { .. } → match *data.boxed_user { User { .. } => ... }
+// nested: Some("hello")   → match **data.nested { Some("hello") => ... }
+```
+
+## Implementation Strategy
+
+### 1. No AST Changes Needed!
+
+The beauty of this approach: **no new pattern variants required**. We use existing patterns and generate appropriate dereferencing.
+
+### 2. Type-Guided Code Generation
+
+Instead of parsing special syntax, we analyze types during code generation:
+
+```rust
+// In expand.rs - modify field assertion generation
+fn generate_field_assertion(field_type: &syn::Type, pattern: &Pattern, field_expr: &TokenStream) -> TokenStream {
+    let deref_count = calculate_deref_distance(field_type, pattern);
+    let deref_expr = apply_derefs(field_expr, deref_count);
+    
+    // Generate normal pattern matching with dereferenced expression
+    generate_pattern_match(deref_expr, pattern)
+}
+
+fn calculate_deref_distance(field_type: &syn::Type, pattern: &Pattern) -> usize {
+    // Analyze field type and pattern to determine how many * operators needed
+    // This is where the magic happens!
+}
+
+fn apply_derefs(expr: &TokenStream, count: usize) -> TokenStream {
+    match count {
+        0 => quote! { #expr },
+        1 => quote! { *#expr },
+        2 => quote! { **#expr },
+        n => {
+            let stars = "*".repeat(n);
+            let stars_tokens = proc_macro2::TokenStream::from_str(&stars).unwrap();
+            quote! { #stars_tokens #expr }
+        }
+    }
+}
+```
+
+### 3. Type Analysis Strategy
+
+The core challenge: **determine when dereferencing is needed**:
+
+```rust
+fn calculate_deref_distance(field_type: &syn::Type, pattern: &Pattern) -> usize {
+    match (field_type, pattern) {
+        // Box<T> field with pattern expecting T
+        (Type::Path(type_path), _) if is_box_type(type_path) => {
+            let inner_type = extract_box_inner_type(type_path);
+            if pattern_expects_type(pattern, &inner_type) {
+                1  // Need one deref: Box<T> -> T
+            } else {
+                0  // Pattern matches Box itself
+            }
+        }
+        
+        // Rc<T> field with pattern expecting T  
+        (Type::Path(type_path), _) if is_rc_type(type_path) => {
+            // Similar logic...
+            1
+        }
+        
+        // Nested: Arc<Box<T>> field with pattern expecting T
+        (Type::Path(type_path), _) if is_arc_type(type_path) => {
+            let inner = extract_arc_inner_type(type_path);
+            if is_box_type(&inner) {
+                let box_inner = extract_box_inner_type(&inner);
+                if pattern_expects_type(pattern, &box_inner) {
+                    2  // Need two derefs: Arc<Box<T>> -> Box<T> -> T
+                } else {
+                    1  // Pattern expects Box<T>
+                }
+            } else {
+                1  // Pattern expects inner type
+            }
+        }
+        
+        _ => 0  // No dereferencing needed
+    }
+}
+```
+
+### 4. Type Constraint Strategy
+
+We need to ensure the smart pointer actually contains the expected type. This happens naturally through Rust's type system, but we should provide clear error messages.
+
+### 5. Error Message Strategy
+
+Extend error messages to show the dereferencing context:
+
+```rust
+// Error output:
+assert_struct! failed:
+
+   | AstNode {
+pattern mismatch:
+  --> `node.expr` (line 15)
+   |     expr: Box<Expr::Literal {
+   |           ^^^^^^^^^^^^^^^^^^^ expected Expr::Literal, found Expr::Binary
+   |         value: > 0,
+   |     }>,
+   | }
+```
+
+## Edge Cases and Considerations
+
+### 1. Multiple Dereference Levels
+
+Support nested smart pointers:
+
+```rust
+// Should work:
+nested: Box<Rc<Option<String>>>,
+triple: Box<Rc<Arc<MyStruct { .. }>>>,
+```
+
+### 2. Generic Type Parameters
+
+Handle generic smart pointers gracefully:
+
+```rust
+// This might be complex:
+generic_box: Box<T> where T: SomePattern,
+```
+
+**Decision**: Start with concrete types only, add generic support later if needed.
+
+### 3. Custom Deref Types
+
+Should we support custom types that implement `Deref`?
+
+**Decision**: Start with std library types (`Box`, `Rc`, `Arc`), add custom support if requested.
+
+### 4. Reference Patterns
+
+How does this interact with existing reference handling?
+
+```rust
+// These should be equivalent:
+field: &Pattern,
+field: Pattern,  // when field is already &T
+```
+
+**Decision**: Let Rust's type system handle this naturally.
+
+### 5. Owned vs Borrowed
+
+```rust
+// Different scenarios:
+owned_box: Box<Pattern>,        // We own the Box
+borrowed_box: &Box<Pattern>,    // We borrow the Box
+```
+
+**Decision**: Generate appropriate dereferencing code based on context.
+
+## Implementation Phases
+
+### Phase 1: Core Auto-Deref Support
+- Add type analysis to `expand.rs` for detecting smart pointer mismatches
+- Implement `calculate_deref_distance()` for Box, Rc, Arc
+- Generate appropriate `*` operators in field assertions
+- Add basic tests for single-level dereferencing
+
+### Phase 2: Multiple Smart Pointer Types & Nesting
+- Support nested smart pointers (Box<Rc<T>>, Arc<Box<T>>, etc.)
+- Handle reference vs owned scenarios properly
+- Comprehensive testing for all combinations
+
+### Phase 3: Integration & Polish
+- Ensure all existing patterns work through auto-deref
+- Error message improvements with deref context
+- Performance testing and optimization
+- Documentation and examples
+
+### Phase 4: Advanced Cases
+- Generic type parameter support (if needed)
+- Custom Deref types (if requested by users)
+- Edge case handling and robustness improvements
+
+## Alternative Approaches Considered
+
+### 1. Explicit Deref Operator
+
+```rust
+// Alternative syntax:
+expr: *Box<Pattern>,
+expr: **Rc<Option<Pattern>>,
+```
+
+**Rejected**: Less readable, doesn't follow Rust's natural container syntax.
+
+### 2. Special Method Syntax
+
+```rust
+// Alternative syntax:
+expr.deref(): Pattern,
+expr.as_ref(): Pattern,
+```
+
+**Rejected**: Would require implementing method call patterns first, more complex.
+
+### 3. Closure-Only Approach
+
+```rust
+// Alternative: Just use closures
+expr: |boxed| matches!(**boxed, Pattern),
+```
+
+**Rejected**: Less ergonomic, doesn't provide structured pattern benefits.
+
+## Testing Strategy
+
+### Unit Tests
+- Basic Box, Rc, Arc patterns
+- Nested smart pointers
+- Integration with all existing pattern types
+- Error cases and edge conditions
+
+### Integration Tests
+- Real-world AST structures
+- Complex nested scenarios
+- Performance benchmarks
+
+### Error Message Tests
+- Snapshot tests for clear error output
+- Various failure scenarios
+
+## Future Extensions
+
+### 1. Pin Support
+```rust
+pinned: Pin<Box<Future>>,
+```
+
+### 2. Custom Deref Types
+Support for user-defined smart pointers.
+
+### 3. Multiple Deref Chains
+Automatically follow multiple `Deref` implementations.
+
+## Summary
+
+This design provides a natural, type-safe way to pattern match through smart pointers while maintaining `assert_struct!`'s core principles of clarity and performance. The phased implementation approach allows us to start with the most common cases and expand based on user feedback.
+
+The key insight is that we can automatically generate appropriate `*` operators based on type analysis rather than requiring special syntax. This leverages Rust's existing match behavior, works with any `Deref` type, and provides maximum composability with existing features while keeping the implementation simple and performant.


### PR DESCRIPTION
## Summary
- Add support for field operations in assert-struct patterns
- Implement explicit dereferencing syntax for struct fields and tuple elements
- Support mixed positional/indexed tuple syntax with operations

## Key Features
- **Field dereferencing**: `*boxed_value: 42` for struct fields
- **Tuple element dereferencing**: `*1: 99` for indexed elements
- **Mixed syntax**: `("test", *1: 99)` combining approaches

## Implementation Details
- New `FieldOperation` enum with `Deref`, `Method`, `Nested`, `Combined` variants
- Extended `FieldAssertion` and added `TupleElement` enum
- Reference-context-aware code generation to handle destructuring properly
- Comprehensive parsing for `*field_name:` and `*index:` syntax

## Test Plan
- [x] Basic struct field dereferencing
- [x] Tuple element dereferencing with indexing
- [x] Mixed positional and indexed tuple syntax
- [x] All tests passing

## Technical Notes
The key insight was that struct destructuring with `match &value { Struct { field, .. } }` creates a reference context where `field` is `&FieldType`. The dereferencing operation needs to account for this extra reference level.