### PR TITLE
Fix CI badge to show main branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # assert-struct
 
-[![CI](https://github.com/carllerche/assert-struct/workflows/CI/badge.svg)](https://github.com/carllerche/assert-struct/actions)
+[![CI](https://github.com/carllerche/assert-struct/workflows/CI/badge.svg?branch=main)](https://github.com/carllerche/assert-struct/actions)
 [![Crates.io](https://img.shields.io/crates/v/assert-struct.svg)](https://crates.io/crates/assert-struct)
 [![Documentation](https://docs.rs/assert-struct/badge.svg)](https://docs.rs/assert-struct)
 


### PR DESCRIPTION
## Problem
The CI badge was showing the status of the most recent workflow run from any branch, rather than specifically showing the main branch status. This could mislead users when feature branch CI runs fail but main is passing.

## Solution
Add `?branch=main` parameter to the CI badge URL to ensure it always reflects the status of the main branch.

## Changes
- Updated CI badge URL from `workflows/CI/badge.svg` to `workflows/CI/badge.svg?branch=main`

## Testing
The badge should now consistently show green when main branch CI passes, regardless of feature branch CI status.

Fixes #33