### PR TITLE
Add wildcard struct patterns to avoid type imports

### DIFF
--- a/assert-struct-macros/src/expand.rs
+++ b/assert-struct-macros/src/expand.rs
@@ -239,7 +239,7 @@ fn generate_pattern_nodes(
             let name_str = if let Some(p) = path {
                 quote! { #p }.to_string().replace(" :: ", "::")
             } else {
-                "_".to_string()  // Use "_" for wildcard struct patterns
+                "_".to_string() // Use "_" for wildcard struct patterns
             };
 
             let field_entries: Vec<TokenStream> = fields
@@ -307,7 +307,7 @@ fn generate_pattern_assertion_with_collection(
             ..
         } => generate_struct_match_assertion_with_collection(
             value_expr,
-            struct_path,  // Now passing &Option<syn::Path>
+            struct_path, // Now passing &Option<syn::Path>
             fields,
             *rest,
             is_ref,
@@ -451,20 +451,20 @@ fn generate_wildcard_struct_assertion_with_collection(
             let field_name = &f.field_name;
             let field_pattern = &f.pattern;
             let field_operations = &f.operations;
-            
-            // Build path for this field 
+
+            // Build path for this field
             let mut new_path = field_path.to_vec();
             new_path.push(field_name.to_string());
-            
+
             // Apply operations if any and determine reference level
             let (accessed_value, is_ref_after) = if let Some(ops) = field_operations {
                 // For method calls, we need to access the field without taking a reference
                 // since the method call will operate on the field directly
                 let base_field_access = quote! { (#value_expr).#field_name };
-                
+
                 // Apply operations - pass false for in_ref_context since we're not taking a reference
                 let expr = apply_field_operations(&base_field_access, ops, false);
-                
+
                 // Operations change the reference level based on their type
                 let is_ref = match ops {
                     FieldOperation::Deref { .. } => false, // Dereferencing removes reference level
@@ -479,17 +479,17 @@ fn generate_wildcard_struct_assertion_with_collection(
                 // field_access is already a reference, so is_ref = true
                 (field_access, true)
             };
-            
+
             // Recursively expand the pattern for this field
             generate_pattern_assertion_with_collection(
                 &accessed_value,
                 field_pattern,
-                is_ref_after, 
+                is_ref_after,
                 &new_path,
             )
         })
         .collect();
-    
+
     quote! {
         #(#field_assertions)*
     }
@@ -508,14 +508,10 @@ fn generate_struct_match_assertion_with_collection(
     // If struct_path is None, it's a wildcard pattern - use field access
     if struct_path.is_none() {
         return generate_wildcard_struct_assertion_with_collection(
-            value_expr,
-            fields,
-            is_ref,
-            field_path,
-            node_ident,
+            value_expr, fields, is_ref, field_path, node_ident,
         );
     }
-    
+
     let struct_path = struct_path.as_ref().unwrap();
     let field_names: Vec<_> = fields.iter().map(|f| &f.field_name).collect();
     let field_path_str = field_path.join(".");
@@ -920,7 +916,7 @@ fn pattern_to_string(pattern: &Pattern) -> String {
             } else {
                 "_ { .. }".to_string()
             }
-        },
+        }
         Pattern::Tuple { path, elements, .. } => {
             if let Some(p) = path {
                 if elements.is_empty() {

--- a/assert-struct-macros/src/expand.rs
+++ b/assert-struct-macros/src/expand.rs
@@ -441,7 +441,7 @@ fn generate_pattern_assertion_with_collection(
 fn generate_wildcard_struct_assertion_with_collection(
     value_expr: &TokenStream,
     fields: &Punctuated<FieldAssertion, Token![,]>,
-    is_ref: bool,
+    _is_ref: bool,
     field_path: &[String],
     _node_ident: &Ident,
 ) -> TokenStream {
@@ -460,11 +460,7 @@ fn generate_wildcard_struct_assertion_with_collection(
             let (accessed_value, is_ref_after) = if let Some(ops) = field_operations {
                 // For method calls, we need to access the field without taking a reference
                 // since the method call will operate on the field directly
-                let base_field_access = if is_ref {
-                    quote! { (#value_expr).#field_name }
-                } else {
-                    quote! { (#value_expr).#field_name }
-                };
+                let base_field_access = quote! { (#value_expr).#field_name };
                 
                 // Apply operations - pass false for in_ref_context since we're not taking a reference
                 let expr = apply_field_operations(&base_field_access, ops, false);
@@ -479,14 +475,7 @@ fn generate_wildcard_struct_assertion_with_collection(
                 (expr, is_ref)
             } else {
                 // No operations - we need a reference to the field for comparison
-                let field_access = if is_ref {
-                    // value_expr is already a reference, so value_expr.field gives us a field value
-                    // We need to take its reference for comparison
-                    quote! { &(#value_expr).#field_name }
-                } else {
-                    // value_expr is not a reference, so we need to reference the field
-                    quote! { &(#value_expr).#field_name }
-                };
+                let field_access = quote! { &(#value_expr).#field_name };
                 // field_access is already a reference, so is_ref = true
                 (field_access, true)
             };

--- a/assert-struct-macros/src/lib.rs
+++ b/assert-struct-macros/src/lib.rs
@@ -45,7 +45,7 @@ pub(crate) enum Pattern {
     // When path is None, it's a wildcard pattern: _ { name: \"Alice\", .. }
     Struct {
         node_id: usize,
-        path: Option<syn::Path>,  // None for wildcard patterns
+        path: Option<syn::Path>, // None for wildcard patterns
         fields: Punctuated<FieldAssertion, Token![,]>,
         rest: bool,
     },

--- a/assert-struct-macros/src/lib.rs
+++ b/assert-struct-macros/src/lib.rs
@@ -42,9 +42,10 @@ pub(crate) enum Pattern {
         expr: Expr,
     },
     // Struct pattern: User { name: \"Alice\", age: 30, .. }
+    // When path is None, it's a wildcard pattern: _ { name: \"Alice\", .. }
     Struct {
         node_id: usize,
-        path: syn::Path,
+        path: Option<syn::Path>,  // None for wildcard patterns
         fields: Punctuated<FieldAssertion, Token![,]>,
         rest: bool,
     },
@@ -135,7 +136,11 @@ impl fmt::Display for Pattern {
             Pattern::Struct {
                 path, fields, rest, ..
             } => {
-                write!(f, "{} {{ ", path_to_string(path))?;
+                if let Some(p) = path {
+                    write!(f, "{} {{ ", path_to_string(p))?;
+                } else {
+                    write!(f, "_ {{ ")?;
+                }
                 for (i, field) in fields.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
@@ -383,6 +388,7 @@ impl fmt::Display for ComparisonOp {
 /// assert_struct!(expression, TypePattern);
 ///
 /// TypePattern ::= TypeName '{' FieldPatternList '}'
+///              | '_' '{' FieldPatternList '}'  // Wildcard pattern
 /// FieldPatternList ::= (FieldPattern ',')* ('..')?
 /// FieldPattern ::= FieldName ':' Pattern
 ///              | FieldName FieldOperation ':' Pattern  
@@ -449,6 +455,13 @@ impl fmt::Display for ComparisonOp {
 /// | **Unit Variant** | `field: EnumType::Variant` | Match unit enum variant | Enum with unit variant |
 /// | **Tuple Variant** | `field: EnumType::Variant(patterns...)` | Match tuple enum variant | Enum with tuple variant |
 /// | **Struct Variant** | `field: EnumType::Variant { fields... }` | Match struct enum variant | Enum with struct variant |
+///
+/// ## Wildcard Struct Patterns
+///
+/// | Pattern | Syntax | Description | Constraints |
+/// |---------|--------|-------------|-------------|
+/// | **Wildcard Struct** | `value: _ { fields... }` | Match struct without naming type | Must use `..` for partial matching |
+/// | **Nested Wildcard** | `_ { field: _ { ... }, .. }` | Nested anonymous structs | Avoids importing nested types |
 ///
 /// ## Collection Patterns
 ///

--- a/assert-struct-macros/src/parse.rs
+++ b/assert-struct-macros/src/parse.rs
@@ -122,26 +122,26 @@ fn parse_pattern(input: ParseStream) -> Result<Pattern> {
     if input.peek(Token![_]) {
         let fork = input.fork();
         let _: Token![_] = fork.parse()?;
-        
+
         // Check if this is a wildcard struct pattern: `_ { ... }`
         if fork.peek(syn::token::Brace) {
             let _: Token![_] = input.parse()?;
             let content;
             syn::braced!(content in input);
             let expected: Expected = content.parse()?;
-            
+
             // Wildcard struct patterns must use rest pattern (..)
             // to indicate partial matching
             if !expected.rest {
                 return Err(syn::Error::new_spanned(
                     quote! { _ },
-                    "Wildcard struct patterns must use '..' for partial matching"
+                    "Wildcard struct patterns must use '..' for partial matching",
                 ));
             }
-            
+
             return Ok(Pattern::Struct {
                 node_id: next_node_id(),
-                path: None,  // None indicates wildcard
+                path: None, // None indicates wildcard
                 fields: expected.fields,
                 rest: expected.rest,
             });

--- a/assert-struct/src/lib.rs
+++ b/assert-struct/src/lib.rs
@@ -467,6 +467,75 @@
 //! });
 //! ```
 //!
+//! ## Wildcard Patterns
+//!
+//! Use wildcard patterns (`_`) to avoid importing types while still asserting on their structure:
+//!
+//! ```rust
+//! # use assert_struct::assert_struct;
+//! # mod api {
+//! #     #[derive(Debug)]
+//! #     pub struct Response {
+//! #         pub user: User,
+//! #         pub metadata: Metadata,
+//! #     }
+//! #     #[derive(Debug)]
+//! #     pub struct User {
+//! #         pub id: u32,
+//! #         pub name: String,
+//! #     }
+//! #     #[derive(Debug)]
+//! #     pub struct Metadata {
+//! #         pub timestamp: u64,
+//! #         pub version: String,
+//! #     }
+//! # }
+//! # let response = api::Response {
+//! #     user: api::User { id: 123, name: "Alice".to_string() },
+//! #     metadata: api::Metadata { timestamp: 1234567890, version: "1.0".to_string() }
+//! # };
+//! // No need to import User or Metadata types!
+//! assert_struct!(response, _ {
+//!     user: _ {
+//!         id: 123,
+//!         name: "Alice",
+//!         ..
+//!     },
+//!     metadata: _ {
+//!         version: "1.0",
+//!         ..  // Ignore other metadata fields
+//!     },
+//!     ..
+//! });
+//! ```
+//!
+//! This is particularly useful when testing API responses where you don't want to import all the nested types:
+//!
+//! ```rust
+//! # use assert_struct::assert_struct;
+//! # #[derive(Debug)]
+//! # struct JsonResponse { data: Data }
+//! # #[derive(Debug)]
+//! # struct Data { items: Vec<Item>, total: u32 }
+//! # #[derive(Debug)]
+//! # struct Item { id: u32, value: String }
+//! # let json_response = JsonResponse {
+//! #     data: Data {
+//! #         items: vec![Item { id: 1, value: "test".to_string() }],
+//! #         total: 1
+//! #     }
+//! # };
+//! // Test deeply nested structures without imports
+//! assert_struct!(json_response, _ {
+//!     data: _ {
+//!         items: [_ { id: 1, value: "test", .. }],
+//!         total: 1,
+//!         ..
+//!     },
+//!     ..
+//! });
+//! ```
+//!
 //! # Error Messages
 //!
 //! When assertions fail, `assert-struct` provides detailed, actionable error messages:

--- a/assert-struct/tests/snapshots/wildcard_struct__wildcard_struct_failure.snap
+++ b/assert-struct/tests/snapshots/wildcard_struct__wildcard_struct_failure.snap
@@ -6,7 +6,7 @@ assert_struct! failed:
 
    | _ { ... _ {
 mismatch:
-  --> `data.inner.value` (line 155)
+  --> `data.inner.value` (line 154)
    |     value: 20,
    |            ^^ actual: 10
    | } ... }

--- a/assert-struct/tests/snapshots/wildcard_struct__wildcard_struct_failure.snap
+++ b/assert-struct/tests/snapshots/wildcard_struct__wildcard_struct_failure.snap
@@ -1,0 +1,12 @@
+---
+source: assert-struct/tests/wildcard_struct.rs
+expression: message
+---
+assert_struct! failed:
+
+   | _ { ... _ {
+mismatch:
+  --> `data.inner.value` (line 155)
+   |     value: 20,
+   |            ^^ actual: 10
+   | } ... }

--- a/assert-struct/tests/wildcard_struct.rs
+++ b/assert-struct/tests/wildcard_struct.rs
@@ -198,8 +198,11 @@ fn test_normal_struct_pattern_still_works() {
     };
 
     // Traditional pattern with type name
-    assert_struct!(data, Inner {
-        value: 100,
-        text: "normal",
-    });
+    assert_struct!(
+        data,
+        Inner {
+            value: 100,
+            text: "normal",
+        }
+    );
 }

--- a/assert-struct/tests/wildcard_struct.rs
+++ b/assert-struct/tests/wildcard_struct.rs
@@ -1,0 +1,200 @@
+/// Tests for wildcard struct patterns that avoid type imports
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Inner {
+    value: i32,
+    text: String,
+}
+
+#[derive(Debug)]
+struct Outer {
+    inner: Inner,
+    count: u32,
+}
+
+#[derive(Debug)]
+struct Complex {
+    outer: Outer,
+    enabled: bool,
+}
+
+#[test]
+fn test_wildcard_struct_simple() {
+    let data = Outer {
+        inner: Inner {
+            value: 42,
+            text: "hello".to_string(),
+        },
+        count: 5,
+    };
+
+    // Using wildcard pattern - no need to import Inner type
+    assert_struct!(data, _ {
+        inner: _ {
+            value: 42,
+            text: "hello",
+            ..
+        },
+        count: 5,
+        ..
+    });
+}
+
+#[test]
+fn test_wildcard_struct_nested() {
+    let data = Complex {
+        outer: Outer {
+            inner: Inner {
+                value: 100,
+                text: "world".to_string(),
+            },
+            count: 10,
+        },
+        enabled: true,
+    };
+
+    // Deep nesting without any type imports
+    assert_struct!(data, _ {
+        outer: _ {
+            inner: _ {
+                value: > 50,
+                text: "world",
+                ..
+            },
+            count: >= 10,
+            ..
+        },
+        enabled: true,
+        ..
+    });
+}
+
+#[test]
+fn test_wildcard_with_comparisons() {
+    let data = Outer {
+        inner: Inner {
+            value: 25,
+            text: "test".to_string(),
+        },
+        count: 8,
+    };
+
+    assert_struct!(data, _ {
+        inner: _ {
+            value: > 20,
+            text: != "other",
+            ..
+        },
+        count: < 10,
+        ..
+    });
+}
+
+// TODO: Fix method calls with wildcard patterns
+// #[test]
+// fn test_wildcard_with_method_calls() {
+//     let data = Outer {
+//         inner: Inner {
+//             value: 0,
+//             text: "hello world".to_string(),
+//         },
+//         count: 3,
+//     };
+
+//     assert_struct!(data, _ {
+//         inner: _ {
+//             text.len(): 11,
+//             text.contains("world"): true,
+//             ..
+//         },
+//         count: > 0,
+//         ..
+//     });
+// }
+
+#[test]
+fn test_wildcard_partial_matching() {
+    let data = Complex {
+        outer: Outer {
+            inner: Inner {
+                value: 42,
+                text: "ignored".to_string(),
+            },
+            count: 99,
+        },
+        enabled: false,
+    };
+
+    // Only check specific fields, ignore the rest
+    assert_struct!(data, _ {
+        outer: _ {
+            inner: _ {
+                value: 42,
+                ..  // Ignore text field
+            },
+            ..  // Ignore count field
+        },
+        ..  // Ignore enabled field
+    });
+}
+
+#[test]
+#[should_panic(expected = "mismatch")]
+fn test_wildcard_struct_failure() {
+    let data = Outer {
+        inner: Inner {
+            value: 10,
+            text: "test".to_string(),
+        },
+        count: 5,
+    };
+
+    assert_struct!(data, _ {
+        inner: _ {
+            value: 20,  // This should fail
+            ..
+        },
+        ..
+    });
+}
+
+#[test]
+fn test_wildcard_with_options() {
+    #[derive(Debug)]
+    struct Container {
+        maybe_inner: Option<Inner>,
+    }
+
+    let data = Container {
+        maybe_inner: Some(Inner {
+            value: 42,
+            text: "present".to_string(),
+        }),
+    };
+
+    // Combine wildcard struct with Option pattern
+    assert_struct!(data, _ {
+        maybe_inner: Some(_ {
+            value: 42,
+            text: "present",
+            ..
+        }),
+        ..
+    });
+}
+
+// This test verifies that normal struct patterns still work
+#[test]
+fn test_normal_struct_pattern_still_works() {
+    let data = Inner {
+        value: 100,
+        text: "normal".to_string(),
+    };
+
+    // Traditional pattern with type name
+    assert_struct!(data, Inner {
+        value: 100,
+        text: "normal",
+    });
+}

--- a/assert-struct/tests/wildcard_struct.rs
+++ b/assert-struct/tests/wildcard_struct.rs
@@ -140,7 +140,6 @@ fn test_wildcard_partial_matching() {
 }
 
 #[test]
-#[should_panic(expected = "mismatch")]
 fn test_wildcard_struct_failure() {
     let data = Outer {
         inner: Inner {
@@ -150,13 +149,20 @@ fn test_wildcard_struct_failure() {
         count: 5,
     };
 
-    assert_struct!(data, _ {
-        inner: _ {
-            value: 20,  // This should fail
+    let message = std::panic::catch_unwind(|| {
+        assert_struct!(data, _ {
+            inner: _ {
+                value: 20,  // This should fail
+                ..
+            },
             ..
-        },
-        ..
-    });
+        });
+    })
+    .unwrap_err()
+    .downcast::<String>()
+    .unwrap();
+
+    insta::assert_snapshot!(message);
 }
 
 #[test]

--- a/assert-struct/tests/wildcard_struct.rs
+++ b/assert-struct/tests/wildcard_struct.rs
@@ -91,27 +91,26 @@ fn test_wildcard_with_comparisons() {
     });
 }
 
-// TODO: Fix method calls with wildcard patterns
-// #[test]
-// fn test_wildcard_with_method_calls() {
-//     let data = Outer {
-//         inner: Inner {
-//             value: 0,
-//             text: "hello world".to_string(),
-//         },
-//         count: 3,
-//     };
+#[test]
+fn test_wildcard_with_method_calls() {
+    let data = Outer {
+        inner: Inner {
+            value: 0,
+            text: "hello world".to_string(),
+        },
+        count: 3,
+    };
 
-//     assert_struct!(data, _ {
-//         inner: _ {
-//             text.len(): 11,
-//             text.contains("world"): true,
-//             ..
-//         },
-//         count: > 0,
-//         ..
-//     });
-// }
+    assert_struct!(data, _ {
+        inner: _ {
+            text.len(): 11,
+            text.contains("world"): true,
+            ..
+        },
+        count: > 0,
+        ..
+    });
+}
 
 #[test]
 fn test_wildcard_partial_matching() {


### PR DESCRIPTION
## Summary

This PR adds support for wildcard struct patterns (`_ { ... }`) that allow users to assert on struct fields without importing the struct types. This is particularly useful when testing API responses or working with deeply nested structures.

## Motivation

When testing complex data structures, especially those from external APIs or deeply nested types, importing all the necessary types can be cumbersome and create unnecessary coupling. The wildcard pattern syntax allows for more flexible testing while maintaining the same assertion capabilities.

## Changes

### Parser Enhancement
- Modified `Pattern::Struct` to support optional path (None for wildcard patterns)
- Added parsing for `_ { ... }` syntax with validation for required `..` rest pattern

### Code Generation
- Created dedicated field access generation for wildcard patterns
- Fixed reference level handling for direct field access
- Updated pattern node generation to handle wildcard structs

### Testing
- Added comprehensive test suite covering:
  - Simple and nested wildcard patterns
  - Wildcard patterns with comparisons and ranges
  - Partial matching with wildcards
  - Integration with Option types
  - Error cases

### Documentation
- Added wildcard pattern section to library documentation
- Updated macro syntax specification
- Included practical examples for API testing scenarios

## Example Usage

```rust
// No need to import User or Metadata types!
assert_struct!(response, _ {
    user: _ {
        id: 123,
        name: "Alice",
        ..
    },
    metadata: _ {
        version: "1.0",
        ..
    },
    ..
});
```

## Known Limitations

Method calls with wildcard patterns have some reference level issues that will be addressed in a future update. Basic field assertions work perfectly.

## Testing

All existing tests pass, and new tests provide comprehensive coverage of the wildcard pattern feature.

Fixes #34