### PR TITLE
Add support for nested field access patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Focus on clean design, good architecture, and comprehensive functionality rather
 ### Core Features (Implemented)
 - **Partial matching**: Check only the fields you care about with `..`
 - **Nested struct support**: Deep assertions without verbose field access chains
+- **Nested field access**: Direct access to nested fields `outer.inner.field: value`
 - **Comparison operators**: `<`, `<=`, `>`, `>=` for numeric assertions
 - **Equality operators**: `==`, `!=` for explicit equality checks
 - **Range patterns**: `18..=65`, `0.0..100.0` for range matching

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ assert_struct!(data, Data {
     ..
 });
 
+// Nested field access
+assert_struct!(company, Company {
+    info.name: "TechCorp",
+    info.address.city: "San Francisco",
+    info.address.zip: > 90000,
+    ..
+});
+
 // Collections
 assert_struct!(response, Response {
     scores: [> 80.0, >= 90.0, < 100.0],

--- a/assert-struct/src/lib.rs
+++ b/assert-struct/src/lib.rs
@@ -161,6 +161,15 @@
 //!     },
 //!     ..
 //! });
+//!
+//! // Direct nested field access (no need to nest structs)
+//! assert_struct!(order, Order {
+//!     customer.name: "Bob",
+//!     customer.address.city: "Paris",
+//!     customer.address.country: "France",
+//!     total: > 50.0,
+//!     ..
+//! });
 //! ```
 //!
 //! # Pattern Types

--- a/assert-struct/tests/nested_field_access.rs
+++ b/assert-struct/tests/nested_field_access.rs
@@ -1,0 +1,258 @@
+// Test nested field access patterns like field.nested.value
+
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Inner {
+    value: i32,
+    text: String,
+}
+
+#[derive(Debug)]
+struct Middle {
+    inner: Inner,
+    count: u32,
+}
+
+#[derive(Debug)]
+struct Outer {
+    middle: Middle,
+    enabled: bool,
+}
+
+#[test]
+fn test_simple_nested_field_access() {
+    let data = Outer {
+        middle: Middle {
+            inner: Inner {
+                value: 42,
+                text: "hello".to_string(),
+            },
+            count: 10,
+        },
+        enabled: true,
+    };
+
+    // Test accessing nested field one level deep
+    assert_struct!(data, Outer {
+        middle.count: 10,
+        enabled: true,
+        ..
+    });
+}
+
+#[test]
+fn test_deep_nested_field_access() {
+    let data = Outer {
+        middle: Middle {
+            inner: Inner {
+                value: 100,
+                text: "world".to_string(),
+            },
+            count: 5,
+        },
+        enabled: false,
+    };
+
+    // Test accessing deeply nested fields
+    assert_struct!(data, Outer {
+        middle.inner.value: 100,
+        middle.inner.text: "world",
+        ..
+    });
+}
+
+#[test]
+fn test_nested_field_with_comparison() {
+    let data = Outer {
+        middle: Middle {
+            inner: Inner {
+                value: 75,
+                text: "test".to_string(),
+            },
+            count: 20,
+        },
+        enabled: true,
+    };
+
+    // Test nested fields with comparison operators
+    assert_struct!(data, Outer {
+        middle.inner.value: > 50,
+        middle.count: >= 20,
+        ..
+    });
+}
+
+#[test]
+fn test_mixed_nested_and_direct_fields() {
+    let data = Outer {
+        middle: Middle {
+            inner: Inner {
+                value: 30,
+                text: "mixed".to_string(),
+            },
+            count: 15,
+        },
+        enabled: true,
+    };
+
+    // Mix nested field access with direct field access
+    assert_struct!(data, Outer {
+        enabled: true,
+        middle.inner.value: 30,
+        middle.count: < 20,
+        ..
+    });
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Container {
+    data: Data,
+    id: u32,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Data {
+    items: Items,
+    name: String,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Items {
+    values: Vec<i32>,
+    tags: Vec<String>,
+}
+
+#[test]
+fn test_nested_field_with_method_calls() {
+    let container = Container {
+        data: Data {
+            items: Items {
+                values: vec![1, 2, 3, 4, 5],
+                tags: vec!["alpha".to_string(), "beta".to_string()],
+            },
+            name: "test_container".to_string(),
+        },
+        id: 123,
+    };
+
+    // Test nested field access with method calls
+    // Note: Method calls on nested fields are not yet supported
+    // We'd need to extend the parser to handle data.name.len() syntax
+    assert_struct!(
+        container,
+        Container {
+            id: 123,
+            // data.name.len(): 14,  // TODO: Not yet supported
+            // data.items.values.len(): 5,  // TODO: Not yet supported
+            ..
+        }
+    );
+}
+
+#[test]
+fn test_partial_nested_matching() {
+    let data = Outer {
+        middle: Middle {
+            inner: Inner {
+                value: 99,
+                text: "partial".to_string(),
+            },
+            count: 7,
+        },
+        enabled: false,
+    };
+
+    // Only check some nested fields, ignore others
+    assert_struct!(data, Outer {
+        middle.inner.value: 99,
+        ..  // Ignore everything else
+    });
+}
+
+// Complex nested structure for comprehensive testing
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Company {
+    info: CompanyInfo,
+    departments: Vec<Department>,
+}
+
+#[derive(Debug)]
+struct CompanyInfo {
+    name: String,
+    address: Address,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Address {
+    street: String,
+    city: String,
+    zip: u32,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Department {
+    name: String,
+    manager: Person,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Person {
+    name: String,
+    age: u32,
+}
+
+#[test]
+fn test_very_complex_nested_access() {
+    let company = Company {
+        info: CompanyInfo {
+            name: "TechCorp".to_string(),
+            address: Address {
+                street: "123 Main St".to_string(),
+                city: "San Francisco".to_string(),
+                zip: 94105,
+            },
+        },
+        departments: vec![Department {
+            name: "Engineering".to_string(),
+            manager: Person {
+                name: "Alice".to_string(),
+                age: 35,
+            },
+        }],
+    };
+
+    // Test complex nested field patterns
+    assert_struct!(company, Company {
+        info.name: "TechCorp",
+        info.address.city: "San Francisco",
+        info.address.zip: > 90000,
+        ..
+    });
+}
+
+// Error message tests
+#[macro_use]
+mod util;
+
+error_message_test!(
+    "nested_field_access_errors/simple_nested_mismatch.rs",
+    simple_nested_mismatch
+);
+
+error_message_test!(
+    "nested_field_access_errors/deep_nested_mismatch.rs",
+    deep_nested_mismatch
+);
+
+error_message_test!(
+    "nested_field_access_errors/nested_comparison_failure.rs",
+    nested_comparison_failure
+);

--- a/assert-struct/tests/nested_field_access_errors/deep_nested_mismatch.rs
+++ b/assert-struct/tests/nested_field_access_errors/deep_nested_mismatch.rs
@@ -1,0 +1,32 @@
+#![allow(dead_code)]
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Level3 {
+    value: String,
+}
+
+#[derive(Debug)]
+struct Level2 {
+    level3: Level3,
+}
+
+#[derive(Debug)]
+struct Level1 {
+    level2: Level2,
+}
+
+pub fn test_case() {
+    let data = Level1 {
+        level2: Level2 {
+            level3: Level3 {
+                value: "actual".to_string(),
+            },
+        },
+    };
+
+    assert_struct!(data, Level1 {
+        level2.level3.value: "expected",  // Should be "actual", will fail
+        ..
+    });
+}

--- a/assert-struct/tests/nested_field_access_errors/nested_comparison_failure.rs
+++ b/assert-struct/tests/nested_field_access_errors/nested_comparison_failure.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code)]
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Data {
+    score: i32,
+}
+
+#[derive(Debug)]
+struct Container {
+    data: Data,
+}
+
+pub fn test_case() {
+    let container = Container {
+        data: Data {
+            score: 25,
+        },
+    };
+
+    assert_struct!(container, Container {
+        data.score: > 50,  // 25 is not > 50, will fail
+        ..
+    });
+}

--- a/assert-struct/tests/nested_field_access_errors/simple_nested_mismatch.rs
+++ b/assert-struct/tests/nested_field_access_errors/simple_nested_mismatch.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code)]
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Inner {
+    value: i32,
+}
+
+#[derive(Debug)]
+struct Outer {
+    inner: Inner,
+}
+
+pub fn test_case() {
+    let data = Outer {
+        inner: Inner {
+            value: 42,
+        },
+    };
+
+    assert_struct!(data, Outer {
+        inner.value: 100,  // Should be 42, will fail
+        ..
+    });
+}

--- a/assert-struct/tests/snapshots/nested_field_access__deep_nested_mismatch.snap
+++ b/assert-struct/tests/snapshots/nested_field_access__deep_nested_mismatch.snap
@@ -1,0 +1,12 @@
+---
+source: assert-struct/tests/nested_field_access.rs
+expression: message
+---
+assert_struct! failed:
+
+   | Level1 {
+mismatch:
+  --> `data.level2.level3.value` (line 29)
+   |     value: "expected",
+   |            ^^^^^^^^^^ actual: "actual"
+   | }

--- a/assert-struct/tests/snapshots/nested_field_access__nested_comparison_failure.snap
+++ b/assert-struct/tests/snapshots/nested_field_access__nested_comparison_failure.snap
@@ -1,0 +1,12 @@
+---
+source: assert-struct/tests/nested_field_access.rs
+expression: message
+---
+assert_struct! failed:
+
+   | Container {
+mismatch:
+  --> `container.data.score` (line 22)
+   |     score: > 50,
+   |            ^^^^ actual: 25
+   | }

--- a/assert-struct/tests/snapshots/nested_field_access__simple_nested_mismatch.snap
+++ b/assert-struct/tests/snapshots/nested_field_access__simple_nested_mismatch.snap
@@ -1,0 +1,12 @@
+---
+source: assert-struct/tests/nested_field_access.rs
+expression: message
+---
+assert_struct! failed:
+
+   | Outer {
+mismatch:
+  --> `data.inner.value` (line 22)
+   |     value: 100,
+   |            ^^^ actual: 42
+   | }


### PR DESCRIPTION
## Summary

This PR adds support for accessing nested struct fields directly using dot notation, eliminating the need for deeply nested struct patterns in assertions.

## Motivation

Previously, to assert on deeply nested fields, users had to write verbose nested patterns:

```rust
assert_struct!(data, Outer {
    middle: Middle {
        inner: Inner {
            value: 100,
            text: "world",
        },
        count: >= 20,
    },
    ..
});
```

This quickly becomes unwieldy for complex data structures.

## Solution

With this PR, users can now use dot notation to access nested fields directly:

```rust
assert_struct!(data, Outer {
    middle.inner.value: 100,
    middle.inner.text: "world",
    middle.count: >= 20,
    ..
});
```

## Implementation Details

- Extended the parser to recognize and handle nested field access patterns (`field.nested.value`)
- Leveraged the existing `FieldOperation::Nested` infrastructure that was already in place
- Added deduplication logic to ensure each top-level field is only bound once in struct patterns
- Properly handles reference levels for both Copy and non-Copy types

## Testing

- Comprehensive test suite in `nested_field_access.rs` covering:
  - Simple nested field access
  - Deep nesting (3+ levels)
  - Nested fields with comparison operators
  - Mixed direct and nested field patterns
  - Error cases with snapshot testing for error messages

## Documentation

- Updated library documentation with nested field examples
- Added examples to README.md
- Updated CLAUDE.md to document the feature

All tests pass, including clippy with strict warnings.