### PR TITLE
Fix span handling for wildcard struct pattern error messages

### DIFF
--- a/assert-struct-macros/src/parse.rs
+++ b/assert-struct-macros/src/parse.rs
@@ -1,7 +1,6 @@
 use crate::{
     AssertStruct, ComparisonOp, Expected, FieldAssertion, FieldOperation, Pattern, TupleElement,
 };
-use quote::quote;
 use std::cell::Cell;
 use syn::{Result, Token, parse::Parse, parse::ParseStream, punctuated::Punctuated};
 
@@ -125,7 +124,7 @@ fn parse_pattern(input: ParseStream) -> Result<Pattern> {
 
         // Check if this is a wildcard struct pattern: `_ { ... }`
         if fork.peek(syn::token::Brace) {
-            let _: Token![_] = input.parse()?;
+            let underscore_token: Token![_] = input.parse()?;
             let content;
             syn::braced!(content in input);
             let expected: Expected = content.parse()?;
@@ -134,7 +133,7 @@ fn parse_pattern(input: ParseStream) -> Result<Pattern> {
             // to indicate partial matching
             if !expected.rest {
                 return Err(syn::Error::new_spanned(
-                    quote! { _ },
+                    underscore_token,
                     "Wildcard struct patterns must use '..' for partial matching",
                 ));
             }

--- a/assert-struct/tests/compile_fail/wildcard_struct_missing_rest.rs
+++ b/assert-struct/tests/compile_fail/wildcard_struct_missing_rest.rs
@@ -1,0 +1,14 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Simple {
+    value: i32,
+}
+
+fn main() {
+    let s = Simple { value: 42 };
+
+    assert_struct!(s, _ {
+        value: 42
+    });
+}

--- a/assert-struct/tests/compile_fail/wildcard_struct_missing_rest.stderr
+++ b/assert-struct/tests/compile_fail/wildcard_struct_missing_rest.stderr
@@ -1,0 +1,5 @@
+error: Wildcard struct patterns must use '..' for partial matching
+  --> tests/compile_fail/wildcard_struct_missing_rest.rs:11:23
+   |
+11 |     assert_struct!(s, _ {
+   |                       ^


### PR DESCRIPTION
Previously, when a wildcard struct pattern was missing the required '..' for partial matching, the error message would point to the entire macro call instead of the specific problematic '_' token.

The issue was in the parse.rs file where `syn::Error::new_spanned` was called with `quote! { _ }` (a synthetic span) instead of the actual parsed underscore token.

Fixed by:
- Capturing the underscore token when parsing: `let underscore_token: Token![_] = input.parse()?`
- Passing the actual token to the error: `syn::Error::new_spanned(underscore_token, ...)`
- Removing unused `quote::quote` import

The error now correctly points to the specific `_` character that's missing the required `..` pattern, making it much easier for users to identify and fix the problem.
