### PR TITLE
Fix regex dependency requirement by re-exporting types

### DIFF
--- a/assert-struct-macros/src/expand.rs
+++ b/assert-struct-macros/src/expand.rs
@@ -1410,7 +1410,7 @@ fn generate_regex_assertion_with_collection(
         quote_spanned! {span=>
             {
                 use ::assert_struct::Like;
-                let re = ::regex::Regex::new(#pattern_str)
+                let re = ::assert_struct::__macro_support::Regex::new(#pattern_str)
                     .expect(concat!("Invalid regex pattern: ", #pattern_str));
                 if !#value_expr.like(&re) {
                     let __line = line!();
@@ -1434,7 +1434,7 @@ fn generate_regex_assertion_with_collection(
         quote_spanned! {span=>
             {
                 use ::assert_struct::Like;
-                let re = ::regex::Regex::new(#pattern_str)
+                let re = ::assert_struct::__macro_support::Regex::new(#pattern_str)
                     .expect(concat!("Invalid regex pattern: ", #pattern_str));
                 if !(&#value_expr).like(&re) {
                     let __line = line!();

--- a/assert-struct/src/lib.rs
+++ b/assert-struct/src/lib.rs
@@ -642,6 +642,10 @@ pub mod error;
 pub mod __macro_support {
     pub use crate::error::{ErrorContext, ErrorType, PatternNode, format_errors_with_root};
 
+    // Re-export regex types for macro expansion when regex feature is enabled
+    #[cfg(feature = "regex")]
+    pub use regex::Regex;
+
     /// Helper function to enable type inference for closure parameters in assert_struct patterns
     #[inline]
     pub fn check_closure_condition<T, F>(value: T, predicate: F) -> bool


### PR DESCRIPTION
## Summary
- Re-export `regex::Regex` through `__macro_support` module to eliminate direct dependency requirement
- Update macro expansion to use re-exported types instead of direct `::regex::Regex` references
- Maintains full backward compatibility

## Problem
Users trying to use regex patterns in `assert_struct!` were encountering compilation errors when their crate didn't have `regex` as a direct dependency:

```
error[E0433]: failed to resolve: could not find `regex` in the list of imported crates
```

## Solution
- Added `regex::Regex` re-export to the `__macro_support` module (feature-gated)
- Updated macro expansion to use `::assert_struct::__macro_support::Regex::new()` instead of `::regex::Regex::new()`
- This follows the established pattern for other macro support functionality

## Test plan
- ✅ All existing tests pass
- ✅ Tests pass with and without `--no-default-features`
- ✅ Clippy passes with strict warnings
- ✅ Code formatting is correct
- ✅ Verified fix works by testing regex patterns without direct regex dependency

🤖 Generated with [Claude Code](https://claude.ai/code)