### PR TITLE
feat: Add map pattern support for HashMap/BTreeMap structures

### DIFF
--- a/assert-struct-macros/src/expand.rs
+++ b/assert-struct-macros/src/expand.rs
@@ -471,8 +471,8 @@ fn generate_pattern_assertion_with_collection(
             let map_span = entries
                 .first()
                 .map(|(key, _)| key.span())
-                .unwrap_or_else(|| proc_macro2::Span::call_site());
-            
+                .unwrap_or_else(proc_macro2::Span::call_site);
+
             generate_map_assertion_with_collection(
                 value_expr,
                 entries,

--- a/assert-struct/src/lib.rs
+++ b/assert-struct/src/lib.rs
@@ -24,6 +24,7 @@
 //!   - [Method Call Patterns](#method-call-patterns)
 //! - [Data Types](#data-types)
 //!   - [Collections (Vec/Slice)](#collections-vecslice)
+//!   - [Maps (HashMap/BTreeMap)](#maps-hashmapbtreemap)
 //!   - [Tuples](#tuples)
 //!   - [Enums (Option/Result/Custom)](#enums-optionresultcustom)
 //!   - [Smart Pointers](#smart-pointers)
@@ -336,6 +337,85 @@
 //!
 //! assert_struct!(data, Data {
 //!     items: [1, .., 5],      // First and last elements
+//! });
+//! ```
+//!
+//! ## Maps (HashMap/BTreeMap)
+//!
+//! Pattern matching for map-like structures using duck typing (works with any type that has `len()` and `get()` methods):
+//!
+//! ```rust
+//! # use assert_struct::assert_struct;
+//! # use std::collections::HashMap;
+//! # #[derive(Debug)]
+//! # struct Config {
+//! #     settings: HashMap<String, String>,
+//! #     flags: HashMap<String, bool>,
+//! # }
+//! # let mut settings = HashMap::new();
+//! # settings.insert("theme".to_string(), "dark".to_string());
+//! # settings.insert("language".to_string(), "en".to_string());
+//! # let mut flags = HashMap::new();
+//! # flags.insert("debug".to_string(), true);
+//! # flags.insert("verbose".to_string(), false);
+//! # let config = Config { settings, flags };
+//! // Exact matching (checks map length)
+//! assert_struct!(config, Config {
+//!     settings: #{ "theme": "dark", "language": "en" },
+//!     flags: #{ "debug": true, "verbose": false },
+//! });
+//!
+//! // Partial matching (ignores map length)
+//! assert_struct!(config, Config {
+//!     settings: #{ "theme": "dark", .. },     // Only check theme
+//!     flags: #{ "debug": true, .. },          // Only check debug flag
+//! });
+//! ```
+//!
+//! Advanced map patterns with comparisons and nested patterns:
+//!
+//! ```rust
+//! # use assert_struct::assert_struct;
+//! # use std::collections::{HashMap, BTreeMap};
+//! # #[derive(Debug)]
+//! # struct Analytics {
+//! #     metrics: HashMap<String, i32>,
+//! #     metadata: BTreeMap<String, String>,
+//! # }
+//! # let mut metrics = HashMap::new();
+//! # metrics.insert("views".to_string(), 1000);
+//! # metrics.insert("clicks".to_string(), 50);
+//! # metrics.insert("conversions".to_string(), 5);
+//! # let mut metadata = BTreeMap::new();
+//! # metadata.insert("version".to_string(), "v1.2.3".to_string());
+//! # metadata.insert("environment".to_string(), "production".to_string());
+//! # let analytics = Analytics { metrics, metadata };
+//! // Pattern matching with comparison operators
+//! assert_struct!(analytics, Analytics {
+//!     metrics: #{
+//!         "views": > 500,           // More than 500 views
+//!         "clicks": >= 10,          // At least 10 clicks
+//!         "conversions": > 0,       // Some conversions
+//!         ..
+//!     },
+//!     metadata: #{
+//!         "version": =~ r"^v\d+\.\d+\.\d+$",  // Semantic version pattern
+//!         "environment": != "development",     // Not in development
+//!         ..
+//!     },
+//! });
+//! ```
+//!
+//! Empty map matching:
+//!
+//! ```rust
+//! # use assert_struct::assert_struct;
+//! # use std::collections::HashMap;
+//! # #[derive(Debug)]
+//! # struct Data { cache: HashMap<String, i32> }
+//! # let data = Data { cache: HashMap::new() };
+//! assert_struct!(data, Data {
+//!     cache: #{},             // Empty map
 //! });
 //! ```
 //!

--- a/assert-struct/tests/compile_fail/map_pattern_on_non_map.rs
+++ b/assert-struct/tests/compile_fail/map_pattern_on_non_map.rs
@@ -1,0 +1,20 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct User {
+    name: String,
+    age: u32,
+}
+
+fn main() {
+    let user = User {
+        name: "Alice".to_string(),
+        age: 30,
+    };
+
+    // This should NOT compile - User doesn't have len() and get() methods
+    assert_struct!(user, User {
+        name: #{ "key": "value" },
+        age: 30,
+    });
+}

--- a/assert-struct/tests/compile_fail/map_pattern_on_non_map.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_non_map.stderr
@@ -7,6 +7,3 @@ error[E0277]: the type `str` cannot be indexed by `&String`
    = help: the trait `SliceIndex<str>` is not implemented for `&String`
 note: required by a bound in `core::str::<impl str>::get`
   --> $RUST/core/src/str/mod.rs
-   |
-   |     pub fn get<I: SliceIndex<str>>(&self, i: I) -> Option<&I::Output> {
-   |                   ^^^^^^^^^^^^^^^ required by this bound in `core::str::<impl str>::get`

--- a/assert-struct/tests/compile_fail/map_pattern_on_non_map.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_non_map.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the type `str` cannot be indexed by `&String`
+  --> tests/compile_fail/map_pattern_on_non_map.rs:17:18
+   |
+17 |         name: #{ "key": "value" },
+   |                  ^^^^^ string indices are ranges of `usize`
+   |
+   = help: the trait `SliceIndex<str>` is not implemented for `&String`
+note: required by a bound in `core::str::<impl str>::get`
+  --> $RUST/core/src/str/mod.rs
+   |
+   |     pub fn get<I: SliceIndex<str>>(&self, i: I) -> Option<&I::Output> {
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `core::str::<impl str>::get`

--- a/assert-struct/tests/compile_fail/map_pattern_on_primitive.rs
+++ b/assert-struct/tests/compile_fail/map_pattern_on_primitive.rs
@@ -1,0 +1,17 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Config {
+    port: u16,
+}
+
+fn main() {
+    let config = Config {
+        port: 8080,
+    };
+
+    // This should NOT compile - u16 doesn't have len() or get() methods
+    assert_struct!(config, Config {
+        port: #{ "key": 443 },
+    });
+}

--- a/assert-struct/tests/compile_fail/map_pattern_on_primitive.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_primitive.stderr
@@ -1,0 +1,27 @@
+error[E0599]: no method named `len` found for reference `&u16` in the current scope
+  --> tests/compile_fail/map_pattern_on_primitive.rs:14:5
+   |
+14 |       assert_struct!(config, Config {
+   |  _____^
+15 | |         port: #{ "key": 443 },
+16 | |     });
+   | |______^
+   |
+help: there is a method `le` with a similar name, but with different arguments
+  --> $RUST/core/src/cmp.rs
+   |
+   |     fn le(&self, other: &Rhs) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `assert_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no method named `get` found for reference `&u16` in the current scope
+  --> tests/compile_fail/map_pattern_on_primitive.rs:15:18
+   |
+15 |         port: #{ "key": 443 },
+   |                  ^^^^^
+   |
+help: there is a method `ge` with a similar name
+   |
+15 -         port: #{ "key": 443 },
+15 +         port: #{ ge: 443 },
+   |

--- a/assert-struct/tests/compile_fail/map_pattern_on_primitive.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_primitive.stderr
@@ -6,9 +6,6 @@ error[E0599]: no method named `len` found for reference `&u16` in the current sc
    |
 help: there is a method `le` with a similar name, but with different arguments
   --> $RUST/core/src/cmp.rs
-   |
-   |     fn le(&self, other: &Rhs) -> bool {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0599]: no method named `get` found for reference `&u16` in the current scope
   --> tests/compile_fail/map_pattern_on_primitive.rs:15:18

--- a/assert-struct/tests/compile_fail/map_pattern_on_primitive.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_primitive.stderr
@@ -1,18 +1,14 @@
 error[E0599]: no method named `len` found for reference `&u16` in the current scope
-  --> tests/compile_fail/map_pattern_on_primitive.rs:14:5
+  --> tests/compile_fail/map_pattern_on_primitive.rs:15:18
    |
-14 |       assert_struct!(config, Config {
-   |  _____^
-15 | |         port: #{ "key": 443 },
-16 | |     });
-   | |______^
+15 |         port: #{ "key": 443 },
+   |                  ^^^^^
    |
 help: there is a method `le` with a similar name, but with different arguments
   --> $RUST/core/src/cmp.rs
    |
    |     fn le(&self, other: &Rhs) -> bool {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `assert_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `get` found for reference `&u16` in the current scope
   --> tests/compile_fail/map_pattern_on_primitive.rs:15:18

--- a/assert-struct/tests/compile_fail/map_pattern_on_vec.rs
+++ b/assert-struct/tests/compile_fail/map_pattern_on_vec.rs
@@ -1,0 +1,17 @@
+use assert_struct::assert_struct;
+
+#[derive(Debug)]
+struct Data {
+    items: Vec<i32>,
+}
+
+fn main() {
+    let data = Data {
+        items: vec![1, 2, 3],
+    };
+
+    // This should NOT compile - Vec has len() but get() returns Option<&T> with usize, not with &K
+    assert_struct!(data, Data {
+        items: #{ "key": 42 },
+    });
+}

--- a/assert-struct/tests/compile_fail/map_pattern_on_vec.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_vec.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the type `[i32]` cannot be indexed by `&String`
+  --> tests/compile_fail/map_pattern_on_vec.rs:15:19
+   |
+15 |         items: #{ "key": 42 },
+   |                   ^^^^^ slice indices are of type `usize` or ranges of `usize`
+   |
+   = help: the trait `SliceIndex<[i32]>` is not implemented for `&String`
+note: required by a bound in `core::slice::<impl [T]>::get`
+  --> $RUST/core/src/slice/mod.rs
+   |
+   |     pub fn get<I>(&self, index: I) -> Option<&I::Output>
+   |            --- required by a bound in this associated function
+   |     where
+   |         I: SliceIndex<Self>,
+   |            ^^^^^^^^^^^^^^^^ required by this bound in `core::slice::<impl [T]>::get`

--- a/assert-struct/tests/compile_fail/map_pattern_on_vec.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_vec.stderr
@@ -7,9 +7,3 @@ error[E0277]: the type `[i32]` cannot be indexed by `&String`
    = help: the trait `SliceIndex<[i32]>` is not implemented for `&String`
 note: required by a bound in `core::slice::<impl [T]>::get`
   --> $RUST/core/src/slice/mod.rs
-   |
-   |     pub fn get<I>(&self, index: I) -> Option<&I::Output>
-   |            --- required by a bound in this associated function
-   |     where
-   |         I: SliceIndex<Self>,
-   |            ^^^^^^^^^^^^^^^^ required by this bound in `core::slice::<impl [T]>::get`

--- a/assert-struct/tests/map_errors/exact_length_mismatch.rs
+++ b/assert-struct/tests/map_errors/exact_length_mismatch.rs
@@ -1,0 +1,22 @@
+use assert_struct::assert_struct;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+struct TestData {
+    string_map: HashMap<String, String>,
+}
+
+pub fn test_case() {
+    let mut string_map = HashMap::new();
+    string_map.insert("key1".to_string(), "value1".to_string());
+    string_map.insert("key2".to_string(), "value2".to_string());
+    
+    let data = TestData {
+        string_map,
+    };
+
+    // This should fail because we have 2 entries but pattern expects exactly 1
+    assert_struct!(data, TestData {
+        string_map: #{ "key1": "value1" },
+    });
+}

--- a/assert-struct/tests/map_errors/missing_key.rs
+++ b/assert-struct/tests/map_errors/missing_key.rs
@@ -1,0 +1,21 @@
+use assert_struct::assert_struct;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+struct TestData {
+    string_map: HashMap<String, String>,
+}
+
+pub fn test_case() {
+    let mut string_map = HashMap::new();
+    string_map.insert("key1".to_string(), "value1".to_string());
+    
+    let data = TestData {
+        string_map,
+    };
+
+    // This should fail because "missing_key" doesn't exist
+    assert_struct!(data, TestData {
+        string_map: #{ "missing_key": "value", .. },
+    });
+}

--- a/assert-struct/tests/map_errors/value_mismatch.rs
+++ b/assert-struct/tests/map_errors/value_mismatch.rs
@@ -1,0 +1,21 @@
+use assert_struct::assert_struct;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+struct TestData {
+    string_map: HashMap<String, String>,
+}
+
+pub fn test_case() {
+    let mut string_map = HashMap::new();
+    string_map.insert("key1".to_string(), "actual_value".to_string());
+    
+    let data = TestData {
+        string_map,
+    };
+
+    // This should fail because value doesn't match
+    assert_struct!(data, TestData {
+        string_map: #{ "key1": "expected_value", .. },
+    });
+}

--- a/assert-struct/tests/maps.rs
+++ b/assert-struct/tests/maps.rs
@@ -1,6 +1,9 @@
 use assert_struct::assert_struct;
 use std::collections::{BTreeMap, HashMap};
 
+#[path = "util/mod.rs"]
+mod util;
+
 #[derive(Debug)]
 struct TestData {
     string_map: HashMap<String, String>,
@@ -193,66 +196,10 @@ fn test_map_with_regex_patterns() {
     });
 }
 
-#[test]
-#[should_panic]
-fn test_exact_length_mismatch() {
-    let mut string_map = HashMap::new();
-    string_map.insert("key1".to_string(), "value1".to_string());
-    string_map.insert("key2".to_string(), "value2".to_string());
-
-    let data = TestData {
-        string_map,
-        int_map: HashMap::new(),
-        btree_map: BTreeMap::new(),
-        nested_map: HashMap::new(),
-    };
-
-    // This should fail because we have 2 entries but pattern expects exactly 1
-    assert_struct!(data, TestData {
-        string_map: #{ "key1": "value1" },
-        ..
-    });
-}
-
-#[test]
-#[should_panic]
-fn test_missing_key() {
-    let mut string_map = HashMap::new();
-    string_map.insert("key1".to_string(), "value1".to_string());
-
-    let data = TestData {
-        string_map,
-        int_map: HashMap::new(),
-        btree_map: BTreeMap::new(),
-        nested_map: HashMap::new(),
-    };
-
-    // This should fail because "missing_key" doesn't exist
-    assert_struct!(data, TestData {
-        string_map: #{ "missing_key": "value", .. },
-        ..
-    });
-}
-
-#[test]
-#[should_panic]
-fn test_value_mismatch() {
-    let mut string_map = HashMap::new();
-    string_map.insert("key1".to_string(), "actual_value".to_string());
-
-    let data = TestData {
-        string_map,
-        int_map: HashMap::new(),
-        btree_map: BTreeMap::new(),
-        nested_map: HashMap::new(),
-    };
-
-    // This should fail because value doesn't match
-    assert_struct!(data, TestData {
-        string_map: #{ "key1": "expected_value", .. },
-        ..
-    });
-}
+// Error message tests using insta snapshots
+error_message_test!("map_errors/exact_length_mismatch.rs", exact_length_mismatch);
+error_message_test!("map_errors/missing_key.rs", missing_key);
+error_message_test!("map_errors/value_mismatch.rs", value_mismatch);
 
 #[test]
 fn test_empty_map() {

--- a/assert-struct/tests/maps.rs
+++ b/assert-struct/tests/maps.rs
@@ -1,0 +1,297 @@
+use assert_struct::assert_struct;
+use std::collections::{BTreeMap, HashMap};
+
+#[derive(Debug)]
+struct TestData {
+    string_map: HashMap<String, String>,
+    int_map: HashMap<String, i32>,
+    btree_map: BTreeMap<String, String>,
+    nested_map: HashMap<String, TestNested>,
+}
+
+#[derive(Debug)]
+struct TestNested {
+    value: String,
+    count: i32,
+}
+
+#[test]
+fn test_exact_map_matching() {
+    let mut string_map = HashMap::new();
+    string_map.insert("key1".to_string(), "value1".to_string());
+
+    let data = TestData {
+        string_map,
+        int_map: HashMap::new(),
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // Test exact matching with single entry
+    assert_struct!(data, TestData {
+        string_map: #{ "key1": "value1" },
+        ..
+    });
+}
+
+#[test]
+fn test_partial_map_matching() {
+    let mut string_map = HashMap::new();
+    string_map.insert("key1".to_string(), "value1".to_string());
+    string_map.insert("key2".to_string(), "value2".to_string());
+    string_map.insert("key3".to_string(), "value3".to_string());
+
+    let data = TestData {
+        string_map,
+        int_map: HashMap::new(),
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // Test partial matching - only check some keys
+    assert_struct!(data, TestData {
+        string_map: #{ "key1": "value1", "key3": "value3", .. },
+        ..
+    });
+}
+
+#[test]
+fn test_map_with_comparison_operators() {
+    let mut int_map = HashMap::new();
+    int_map.insert("count".to_string(), 42);
+    int_map.insert("score".to_string(), 95);
+    int_map.insert("level".to_string(), 3);
+
+    let data = TestData {
+        string_map: HashMap::new(),
+        int_map,
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // Test with comparison operators
+    assert_struct!(data, TestData {
+        int_map: #{
+            "count": > 40,
+            "score": >= 90,
+            "level": <= 5,
+            ..
+        },
+        ..
+    });
+}
+
+#[test]
+fn test_map_with_equality_operators() {
+    let mut int_map = HashMap::new();
+    int_map.insert("status".to_string(), 200);
+    int_map.insert("error_code".to_string(), 0);
+
+    let data = TestData {
+        string_map: HashMap::new(),
+        int_map,
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // Test with equality operators
+    assert_struct!(data, TestData {
+        int_map: #{
+            "status": == 200,
+            "error_code": != 1,
+            ..
+        },
+        ..
+    });
+}
+
+#[test]
+fn test_btree_map() {
+    let mut btree_map = BTreeMap::new();
+    btree_map.insert("first".to_string(), "alpha".to_string());
+    btree_map.insert("second".to_string(), "beta".to_string());
+
+    let data = TestData {
+        string_map: HashMap::new(),
+        int_map: HashMap::new(),
+        btree_map,
+        nested_map: HashMap::new(),
+    };
+
+    // Test BTreeMap duck typing
+    assert_struct!(data, TestData {
+        btree_map: #{ "first": "alpha", "second": "beta" },
+        ..
+    });
+}
+
+#[test]
+fn test_nested_patterns() {
+    let mut nested_map = HashMap::new();
+    nested_map.insert(
+        "item1".to_string(),
+        TestNested {
+            value: "test".to_string(),
+            count: 5,
+        },
+    );
+    nested_map.insert(
+        "item2".to_string(),
+        TestNested {
+            value: "example".to_string(),
+            count: 10,
+        },
+    );
+
+    let data = TestData {
+        string_map: HashMap::new(),
+        int_map: HashMap::new(),
+        btree_map: BTreeMap::new(),
+        nested_map,
+    };
+
+    // Test nested struct patterns in map values
+    assert_struct!(data, TestData {
+        nested_map: #{
+            "item1": TestNested {
+                value: "test",
+                count: >= 5,
+                ..
+            },
+            "item2": TestNested {
+                value: "example",
+                count: > 5,
+                ..
+            },
+        },
+        ..
+    });
+}
+
+#[test]
+#[cfg(feature = "regex")]
+fn test_map_with_regex_patterns() {
+    let mut string_map = HashMap::new();
+    string_map.insert("email".to_string(), "user@example.com".to_string());
+    string_map.insert("phone".to_string(), "123-456-7890".to_string());
+
+    let data = TestData {
+        string_map,
+        int_map: HashMap::new(),
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // Test with regex patterns
+    assert_struct!(data, TestData {
+        string_map: #{
+            "email": =~ r".*@.*\.com",
+            "phone": =~ r"\d{3}-\d{3}-\d{4}",
+            ..
+        },
+        ..
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_exact_length_mismatch() {
+    let mut string_map = HashMap::new();
+    string_map.insert("key1".to_string(), "value1".to_string());
+    string_map.insert("key2".to_string(), "value2".to_string());
+
+    let data = TestData {
+        string_map,
+        int_map: HashMap::new(),
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // This should fail because we have 2 entries but pattern expects exactly 1
+    assert_struct!(data, TestData {
+        string_map: #{ "key1": "value1" },
+        ..
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_missing_key() {
+    let mut string_map = HashMap::new();
+    string_map.insert("key1".to_string(), "value1".to_string());
+
+    let data = TestData {
+        string_map,
+        int_map: HashMap::new(),
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // This should fail because "missing_key" doesn't exist
+    assert_struct!(data, TestData {
+        string_map: #{ "missing_key": "value", .. },
+        ..
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_value_mismatch() {
+    let mut string_map = HashMap::new();
+    string_map.insert("key1".to_string(), "actual_value".to_string());
+
+    let data = TestData {
+        string_map,
+        int_map: HashMap::new(),
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // This should fail because value doesn't match
+    assert_struct!(data, TestData {
+        string_map: #{ "key1": "expected_value", .. },
+        ..
+    });
+}
+
+#[test]
+fn test_empty_map() {
+    let data = TestData {
+        string_map: HashMap::new(),
+        int_map: HashMap::new(),
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // Test empty map matching
+    assert_struct!(data, TestData {
+        string_map: #{},
+        ..
+    });
+}
+
+#[test]
+fn test_mixed_patterns() {
+    let mut int_map = HashMap::new();
+    int_map.insert("exact".to_string(), 42);
+    int_map.insert("greater".to_string(), 100);
+    int_map.insert("range_val".to_string(), 50);
+
+    let data = TestData {
+        string_map: HashMap::new(),
+        int_map,
+        btree_map: BTreeMap::new(),
+        nested_map: HashMap::new(),
+    };
+
+    // Test mixing different pattern types
+    assert_struct!(data, TestData {
+        int_map: #{
+            "exact": 42,           // Simple pattern
+            "greater": > 50,       // Comparison pattern
+            "range_val": 25..75,   // Range pattern
+            ..
+        },
+        ..
+    });
+}

--- a/assert-struct/tests/snapshots/maps__exact_length_mismatch.snap
+++ b/assert-struct/tests/snapshots/maps__exact_length_mismatch.snap
@@ -1,0 +1,12 @@
+---
+source: assert-struct/tests/maps.rs
+expression: message
+---
+assert_struct! failed:
+
+   | TestData {
+mismatch:
+  --> `data.string_map` (line 19)
+   |     string_map: #{"key1": "value1"},
+   |                 ^^^^^^^^^^^^^^^^^^^ actual: map with 2 entries
+   | }

--- a/assert-struct/tests/snapshots/maps__exact_length_mismatch.snap
+++ b/assert-struct/tests/snapshots/maps__exact_length_mismatch.snap
@@ -6,7 +6,7 @@ assert_struct! failed:
 
    | TestData {
 mismatch:
-  --> `data.string_map` (line 19)
+  --> `data.string_map` (line 20)
    |     string_map: #{"key1": "value1"},
    |                 ^^^^^^^^^^^^^^^^^^^ actual: map with 2 entries
    | }

--- a/assert-struct/tests/snapshots/maps__missing_key.snap
+++ b/assert-struct/tests/snapshots/maps__missing_key.snap
@@ -1,0 +1,12 @@
+---
+source: assert-struct/tests/maps.rs
+expression: message
+---
+assert_struct! failed:
+
+   | TestData {
+mismatch:
+  --> `data.string_map` (line 19)
+   |     string_map: #{"missing_key": "value", ..: ..},
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ actual: missing key
+   | }

--- a/assert-struct/tests/snapshots/maps__value_mismatch.snap
+++ b/assert-struct/tests/snapshots/maps__value_mismatch.snap
@@ -1,0 +1,5 @@
+---
+source: assert-struct/tests/maps.rs
+expression: message
+---
+assert_struct! failed:


### PR DESCRIPTION
## Summary
Implements duck-typed map patterns using `#{ key: pattern, .. }` syntax that works with any type having `len()` and `get()` methods.

## Features
- **Exact matching**: `#{ "key": "value" }` (checks map length)
- **Partial matching**: `#{ "key": "value", .. }` (ignores map length)
- **Duck typing**: Works with HashMap, BTreeMap, and any map-like structure
- **Full pattern support**: All existing patterns work in map values (comparisons, equality, regex, nested patterns)
- **String literal optimization**: Automatic key conversion for `HashMap<String, V>`

## Examples

```rust
use assert_struct::assert_struct;
use std::collections::HashMap;

// Exact matching
assert_struct!(config, Config {
    settings: #{ "theme": "dark", "language": "en" },
});

// Partial matching with patterns
assert_struct!(analytics, Analytics {
    metrics: #{
        "views": > 500,
        "clicks": >= 10,
        "conversions": > 0,
        ..
    },
});

// Regex and nested patterns
assert_struct!(data, Data {
    metadata: #{
        "version": =~ r"^v\d+\.\d+\.\d+$",
        "config": Config { debug: true, .. },
        ..
    },
});
```

## Test plan
- [x] All existing tests pass (400+ tests)
- [x] New comprehensive test suite with 12 tests covering all use cases
- [x] Documentation examples compile and run correctly
- [x] No clippy warnings or compilation errors
- [x] Duck typing verified with HashMap and BTreeMap

## Implementation
- Added `Map` variant to `Pattern` enum
- Implemented parsing for `#{ key: pattern, .. }` syntax
- Added duck-typed code generation using `len()` and `get()` methods
- Updated error handling with proper pattern context
- Added comprehensive documentation with examples