### PR TITLE
Add map pattern support with duck typing

### DIFF
--- a/assert-struct-macros/src/expand.rs
+++ b/assert-struct-macros/src/expand.rs
@@ -1632,13 +1632,13 @@ fn generate_map_assertion_with_collection(
         let expected_len = entries.len();
         quote_spanned! {map_span=>
             // Check exact length for maps without rest pattern
-            if #value_expr.len() != #expected_len {
+            if (#value_expr).len() != #expected_len {
                 let __line = line!();
                 let __file = file!();
                 let __error = ::assert_struct::__macro_support::ErrorContext {
                     field_path: #field_path_str.to_string(),
                     pattern_str: format!("#{{ {} entries }}", #expected_len),
-                    actual_value: format!("map with {} entries", #value_expr.len()),
+                    actual_value: format!("map with {} entries", (#value_expr).len()),
                     line_number: __line,
                     file_name: __file,
                     error_type: ::assert_struct::__macro_support::ErrorType::Value,
@@ -1679,10 +1679,10 @@ fn generate_map_assertion_with_collection(
                 })
             ) {
                 // For string literals, convert to String to match HashMap<String, V>
-                quote_spanned! {span=> #value_expr.get(&(#key).to_string()) }
+                quote_spanned! {span=> (#value_expr).get(&(#key).to_string()) }
             } else {
                 // For other expressions, try as-is
-                quote_spanned! {span=> #value_expr.get(&#key) }
+                quote_spanned! {span=> (#value_expr).get(&#key) }
             };
 
             quote_spanned! {span=>


### PR DESCRIPTION
## Summary

Implements map patterns for ergonomic matching of map-like structures using duck typing.

## New Syntax

- `#{ "key": pattern }` - Exact map matching (checks length)  
- `#{ "key": pattern, .. }` - Partial matching (ignores extra keys)
- `#{}` - Empty map matching
- `#{ .. }` - Wildcard matching (any map content)

## Features

- **Duck typing**: Works with any type implementing `len()` and `get(K) -> Option<&V>`
- **Pattern support**: All existing patterns work in values (comparisons, ranges, regex, nested structs)
- **Type flexibility**: Supports HashMap, BTreeMap, and custom map types
- **Rich error messages**: Clear failures with field paths and pattern context

## Examples

```rust
assert_struct!(response, ApiResponse {
    headers: #{
        "content-type": "application/json",
        "status": == 200,
        ..
    },
    data: #{
        "users": [> 0],
        "total": >= 100,
        ..
    },
    ..
});
```

## Implementation

- Added `Map` variant to `Pattern` enum with entries and rest flag
- Implemented parsing for `#{ key: pattern }` syntax  
- Generated duck-typed assertions checking `len()` and `get()` methods
- Added comprehensive tests including custom map types
- Fixed type comparison issues with complex expressions

## Testing

- 17+ map-specific tests covering all scenarios
- Custom map type tests demonstrating duck typing
- Empty and wildcard pattern edge cases
- Integration with existing pattern types
- Error message snapshot tests

All tests pass with full CI validation.