### PR TITLE
fix: Add map pattern support for enum variants

### DIFF
--- a/assert-struct-macros/src/parse.rs
+++ b/assert-struct-macros/src/parse.rs
@@ -794,6 +794,14 @@ fn check_for_special_syntax(content: ParseStream) -> bool {
         return true;
     }
 
+    // Map patterns like `Some(#{ "key": "value" })`
+    if content.peek(Token![#]) {
+        let fork = content.fork();
+        if fork.parse::<Token![#]>().is_ok() && fork.peek(syn::token::Brace) {
+            return true;
+        }
+    }
+
     // Check for indexed elements and method calls: `0:`, `1.method():`
     let fork = content.fork();
     if let Ok(_index_lit) = fork.parse::<syn::LitInt>() {

--- a/assert-struct/tests/compile_fail/map_pattern_on_non_map.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_non_map.stderr
@@ -7,3 +7,6 @@ error[E0277]: the type `str` cannot be indexed by `&String`
    = help: the trait `SliceIndex<str>` is not implemented for `&String`
 note: required by a bound in `core::str::<impl str>::get`
   --> $RUST/core/src/str/mod.rs
+   |
+   |     pub fn get<I: SliceIndex<str>>(&self, i: I) -> Option<&I::Output> {
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `core::str::<impl str>::get`

--- a/assert-struct/tests/compile_fail/map_pattern_on_primitive.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_primitive.stderr
@@ -6,6 +6,9 @@ error[E0599]: no method named `len` found for reference `&u16` in the current sc
    |
 help: there is a method `le` with a similar name, but with different arguments
   --> $RUST/core/src/cmp.rs
+   |
+   |     fn le(&self, other: &Rhs) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0599]: no method named `get` found for reference `&u16` in the current scope
   --> tests/compile_fail/map_pattern_on_primitive.rs:15:18

--- a/assert-struct/tests/compile_fail/map_pattern_on_vec.stderr
+++ b/assert-struct/tests/compile_fail/map_pattern_on_vec.stderr
@@ -7,3 +7,9 @@ error[E0277]: the type `[i32]` cannot be indexed by `&String`
    = help: the trait `SliceIndex<[i32]>` is not implemented for `&String`
 note: required by a bound in `core::slice::<impl [T]>::get`
   --> $RUST/core/src/slice/mod.rs
+   |
+   |     pub fn get<I>(&self, index: I) -> Option<&I::Output>
+   |            --- required by a bound in this associated function
+   |     where
+   |         I: SliceIndex<Self>,
+   |            ^^^^^^^^^^^^^^^^ required by this bound in `core::slice::<impl [T]>::get`

--- a/assert-struct/tests/compile_fail/span_propagation_await.stderr
+++ b/assert-struct/tests/compile_fail/span_propagation_await.stderr
@@ -2,13 +2,11 @@ error[E0277]: `&i32` is not a future
   --> tests/compile_fail/span_propagation_await.rs:15:15
    |
 15 |         value.await: 42,
-   |               ^^^^^ `&i32` is not a future
+   |              -^^^^^
+   |              ||
+   |              |`&i32` is not a future
+   |              help: remove the `.await`
    |
    = help: the trait `Future` is not implemented for `&i32`
    = note: &i32 must be a future or must implement `IntoFuture` to be awaited
    = note: required for `&i32` to implement `IntoFuture`
-help: remove the `.await`
-   |
-15 -         value.await: 42,
-15 +         value: 42,
-   |


### PR DESCRIPTION
close: #52 
Enable map syntax (#{ "key": "value" }) inside enum variants like Some() and Ok(). Previously, only slice patterns worked in this context.

- Extend parser to recognize # followed by { in enum variant arguments
- Add comprehensive tests for Option<HashMap> and Result<HashMap> patterns
- Support nested patterns like Ok(Some(#{ ... }))
- Update compile test stderr files for new error messages

Fixes the inability to use map patterns inside enum variants while maintaining consistency with existing slice pattern support.