### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assert-struct"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "annotate-snippets",
  "assert-struct-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assert-struct"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "annotate-snippets",
  "assert-struct-macros",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "assert-struct-macros"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "assert-struct",
  "proc-macro2",

--- a/assert-struct-macros/CHANGELOG.md
+++ b/assert-struct-macros/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/carllerche/assert-struct/compare/assert-struct-macros-v0.4.2...assert-struct-macros-v0.5.0) - 2026-08-14
+
+### Added
+
+- [**breaking**] remove deprecated anonymous struct pattern syntax ([#155](https://github.com/carllerche/assert-struct/pull/155))
+
+### Fixed
+
+- prevent struct field bindings from shadowing expected expressions ([#153](https://github.com/carllerche/assert-struct/pull/153))
+
 ### Removed
 
 - remove deprecated `_ { ... }` anonymous struct syntax and redundant trailing `..` in anonymous structs

--- a/assert-struct-macros/Cargo.toml
+++ b/assert-struct-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-struct-macros"
-version = "0.4.2"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/assert-struct/CHANGELOG.md
+++ b/assert-struct/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/carllerche/assert-struct/compare/assert-struct-v0.4.2...assert-struct-v0.4.3) - 2026-04-28
+
+### Other
+
+- bump tokio from 1.50.0 to 1.52.1 ([#132](https://github.com/carllerche/assert-struct/pull/132))
+- bump insta from 1.46.3 to 1.47.2 ([#126](https://github.com/carllerche/assert-struct/pull/126))
+
 ## [0.4.2](https://github.com/carllerche/assert-struct/compare/assert-struct-v0.4.1...assert-struct-v0.4.2) - 2026-03-11
 
 ### Other

--- a/assert-struct/CHANGELOG.md
+++ b/assert-struct/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/carllerche/assert-struct/compare/assert-struct-v0.4.2...assert-struct-v0.5.0) - 2026-08-14
+
+### Added
+
+- [**breaking**] remove deprecated anonymous struct pattern syntax ([#155](https://github.com/carllerche/assert-struct/pull/155))
+
+### Fixed
+
+- prevent struct field bindings from shadowing expected expressions ([#153](https://github.com/carllerche/assert-struct/pull/153))
+
+### Other
+
+- bump tokio from 1.50.0 to 1.52.1 ([#132](https://github.com/carllerche/assert-struct/pull/132))
+- bump insta from 1.46.3 to 1.47.2 ([#126](https://github.com/carllerche/assert-struct/pull/126))
+
 ### Removed
 
 - remove deprecated `_ { ... }` anonymous struct syntax and redundant trailing `..` in anonymous structs

--- a/assert-struct/Cargo.toml
+++ b/assert-struct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-struct"
-version = "0.4.2"
+version = "0.4.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/assert-struct/Cargo.toml
+++ b/assert-struct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assert-struct"
-version = "0.4.2"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ default = ["regex"]
 regex = ["assert-struct-macros/regex", "dep:regex"]
 
 [dependencies]
-assert-struct-macros = { version = "0.4.2", path = "../assert-struct-macros" }
+assert-struct-macros = { version = "0.5.0", path = "../assert-struct-macros" }
 annotate-snippets = "0.12"
 regex = { workspace = true, optional = true }
 


### PR DESCRIPTION



## 🤖 New release

* `assert-struct-macros`: 0.4.2 -> 0.5.0
* `assert-struct`: 0.4.2 -> 0.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `assert-struct-macros`

<blockquote>

## [0.5.0](https://github.com/carllerche/assert-struct/compare/assert-struct-macros-v0.4.2...assert-struct-macros-v0.5.0) - 2026-08-14

### Added

- [**breaking**] remove deprecated anonymous struct pattern syntax ([#155](https://github.com/carllerche/assert-struct/pull/155))

### Fixed

- prevent struct field bindings from shadowing expected expressions ([#153](https://github.com/carllerche/assert-struct/pull/153))

### Removed

- remove deprecated `_ { ... }` anonymous struct syntax and redundant trailing `..` in anonymous structs

### Fixed

- prevent named struct field bindings from shadowing expected expressions ([#143](https://github.com/carllerche/assert-struct/issues/143))
</blockquote>

## `assert-struct`

<blockquote>

## [0.5.0](https://github.com/carllerche/assert-struct/compare/assert-struct-v0.4.2...assert-struct-v0.5.0) - 2026-08-14

### Added

- [**breaking**] remove deprecated anonymous struct pattern syntax ([#155](https://github.com/carllerche/assert-struct/pull/155))

### Fixed

- prevent struct field bindings from shadowing expected expressions ([#153](https://github.com/carllerche/assert-struct/pull/153))

### Other

- bump tokio from 1.50.0 to 1.52.1 ([#132](https://github.com/carllerche/assert-struct/pull/132))
- bump insta from 1.46.3 to 1.47.2 ([#126](https://github.com/carllerche/assert-struct/pull/126))

### Removed

- remove deprecated `_ { ... }` anonymous struct syntax and redundant trailing `..` in anonymous structs

### Fixed

- prevent named struct field bindings from shadowing expected expressions ([#143](https://github.com/carllerche/assert-struct/issues/143))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).