### PR TITLE
fix: prevent struct field bindings from shadowing expected expressions

### DIFF
--- a/assert-struct-macros/CHANGELOG.md
+++ b/assert-struct-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- prevent named struct field bindings from shadowing expected expressions ([#143](https://github.com/carllerche/assert-struct/issues/143))
+
 ## [0.4.2](https://github.com/carllerche/assert-struct/compare/assert-struct-macros-v0.4.1...assert-struct-macros-v0.4.2) - 2026-03-11
 
 ### Other

--- a/assert-struct-macros/src/expand.rs
+++ b/assert-struct-macros/src/expand.rs
@@ -2,15 +2,15 @@ mod nodes;
 
 use crate::AssertStruct;
 use crate::pattern::{
-    ComparisonOp, FieldAssertion, FieldOperation, Pattern, PatternClosure, PatternComparison,
-    PatternEnum, PatternMap, PatternRange, PatternSet, PatternSimple, PatternSlice, PatternString,
-    PatternStruct, PatternTuple, PatternWildcard, TupleElement,
+    ComparisonOp, FieldAssertion, FieldName, FieldOperation, Pattern, PatternClosure,
+    PatternComparison, PatternEnum, PatternMap, PatternRange, PatternSet, PatternSimple,
+    PatternSlice, PatternString, PatternStruct, PatternTuple, PatternWildcard, TupleElement,
 };
 #[cfg(feature = "regex")]
 use crate::pattern::{PatternLike, PatternRegex};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned};
-use std::collections::HashSet;
+use std::collections::{HashMap, hash_map::Entry};
 use syn::{Token, punctuated::Punctuated, spanned::Spanned};
 
 use nodes::{expand_pattern_node_ident, generate_pattern_nodes};
@@ -140,18 +140,35 @@ fn expand_struct_assertion(value_expr: &TokenStream, pattern: &PatternStruct) ->
 
     // For nested field access, we need to collect unique field names only
     // If we have middle.inner.value and middle.count, we only want "middle" once
-    let mut unique_field_names = HashSet::new();
-    let field_names: Vec<_> = fields
-        .iter()
-        .filter_map(|f| {
-            let field_name = f.operations.root_field_name();
-            if unique_field_names.insert(field_name.clone()) {
-                Some(field_name)
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut field_bindings = HashMap::new();
+    let mut field_patterns = Vec::new();
+
+    for field in fields {
+        let field_name = field.operations.root_field_name();
+
+        if let Entry::Vacant(entry) = field_bindings.entry(field_name.clone()) {
+            // Keep generated bindings hygienically distinct from identifiers in
+            // caller-provided expected expressions while preserving their source
+            // spelling and location for readable expansions and diagnostics.
+            let binding = match &field_name {
+                FieldName::Ident(field_ident) => {
+                    let mut binding = field_ident.clone();
+                    binding.set_span(field_ident.span().resolved_at(Span::mixed_site()));
+                    binding
+                }
+                FieldName::Index(_) => Ident::new(
+                    &format!("__assert_struct_field_{}", field_patterns.len()),
+                    field
+                        .operations
+                        .root_field_span()
+                        .resolved_at(Span::mixed_site()),
+                ),
+            };
+
+            field_patterns.push(quote! { #field_name: #binding });
+            entry.insert(binding);
+        }
+    }
 
     let rest_pattern = if rest {
         quote! { , .. }
@@ -163,9 +180,18 @@ fn expand_struct_assertion(value_expr: &TokenStream, pattern: &PatternStruct) ->
         .iter()
         .map(|f| {
             let field_name = f.operations.root_field_name();
+            let field_binding = field_bindings
+                .get(&field_name)
+                .expect("every asserted field must have a match binding");
+            let mut field_reference = field_binding.clone();
+            field_reference.set_span(
+                field_binding
+                    .span()
+                    .located_at(f.operations.root_field_span()),
+            );
 
-            // Expand the FieldAssertion starting from the bound field name
-            let assertion = expand_field_assertion(&quote! { #field_name }, f);
+            // Expand the FieldAssertion starting from its hygienic match binding.
+            let assertion = expand_field_assertion(&quote! { #field_reference }, f);
 
             // Wrap the assertion with the span of the field pattern if available
             if let Some(span) = f.pattern.span() {
@@ -188,7 +214,7 @@ fn expand_struct_assertion(value_expr: &TokenStream, pattern: &PatternStruct) ->
     quote_spanned! {span=>
         #[allow(unreachable_patterns)]
         match &#value_expr {
-            #struct_path { #(#field_names),* #rest_pattern } => {
+            #struct_path { #(#field_patterns),* #rest_pattern } => {
                 #(#field_assertions)*
             },
             _ => {
@@ -284,7 +310,10 @@ fn apply_field_operations(base_expr: &TokenStream, operation: &FieldOperation) -
             }
         }
         FieldOperation::Await { span } => {
-            quote_spanned! { *span=> #base_expr.await }
+            // Keep the await token in the same hygiene context as a generated
+            // field binding so rustc can construct its "remove `.await`" fix.
+            let span = span.resolved_at(Span::mixed_site());
+            quote_spanned! {span=> #base_expr.await }
         }
         FieldOperation::NamedField { name, span } => {
             quote_spanned! { *span=> #base_expr.#name }

--- a/assert-struct-macros/src/pattern.rs
+++ b/assert-struct-macros/src/pattern.rs
@@ -24,7 +24,7 @@ mod regex;
 pub(crate) use closure::PatternClosure;
 pub(crate) use comparison::{ComparisonOp, PatternComparison};
 pub(crate) use enum_pattern::PatternEnum;
-pub(crate) use field::{FieldAssertion, FieldOperation};
+pub(crate) use field::{FieldAssertion, FieldName, FieldOperation};
 pub(crate) use map::PatternMap;
 pub(crate) use range::PatternRange;
 pub(crate) use set::PatternSet;

--- a/assert-struct-macros/src/pattern/field.rs
+++ b/assert-struct-macros/src/pattern/field.rs
@@ -228,6 +228,21 @@ impl FieldOperation {
         }
     }
 
+    /// Get the source span of the root field access.
+    pub(crate) fn root_field_span(&self) -> proc_macro2::Span {
+        match self {
+            FieldOperation::NamedField { span, .. } | FieldOperation::UnnamedField { span, .. } => {
+                *span
+            }
+            FieldOperation::Chained { operations, .. } => operations
+                .iter()
+                .find(|op| !matches!(op, FieldOperation::Deref { .. }))
+                .expect("Chained operation must have at least one non-Deref operation")
+                .root_field_span(),
+            _ => panic!("Cannot extract root field span from {:?}", self),
+        }
+    }
+
     /// Get operations after the root field access (tail operations)
     /// For NamedField/UnnamedField alone, returns None (no additional operations)
     /// For Chained, returns all operations except the first non-Deref field access

--- a/assert-struct/CHANGELOG.md
+++ b/assert-struct/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- prevent named struct field bindings from shadowing expected expressions ([#143](https://github.com/carllerche/assert-struct/issues/143))
+
 ## [0.4.2](https://github.com/carllerche/assert-struct/compare/assert-struct-v0.4.1...assert-struct-v0.4.2) - 2026-03-11
 
 ### Other

--- a/assert-struct/tests/basic.rs
+++ b/assert-struct/tests/basic.rs
@@ -23,6 +23,11 @@ struct TupleHolder {
     active: bool,
 }
 
+#[derive(Debug)]
+struct IdHolder {
+    id: u32,
+}
+
 #[test]
 fn assert_eq_one_level() {
     let user = User {
@@ -47,6 +52,15 @@ fn partial_match_with_rest() {
     };
 
     assert_struct!(user, User { name: "Bob", .. });
+}
+
+#[test]
+#[should_panic(expected = "assert_struct! failed")]
+fn expected_expression_is_not_shadowed_by_field_binding() {
+    let id = 12;
+    let holder = IdHolder { id: 13 };
+
+    assert_struct!(holder, IdHolder { id: == id });
 }
 
 // Error message tests using snapshot testing

--- a/assert-struct/tests/compile_fail/span_propagation_await.stderr
+++ b/assert-struct/tests/compile_fail/span_propagation_await.stderr
@@ -7,6 +7,7 @@ error[E0277]: `&i32` is not a future
    = help: the trait `Future` is not implemented for `&i32`
    = note: &i32 must be a future or must implement `IntoFuture` to be awaited
    = note: required for `&i32` to implement `IntoFuture`
+   = note: this error originates in the macro `assert_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: remove the `.await`
    |
 15 -         value.await: 42,


### PR DESCRIPTION
## Summary

- Generate hygienic bindings for named and unnamed struct fields.
- Preserve source spans for readable diagnostics and `.await` suggestions.
- Add regression coverage for expected expressions that share field names.
- Update changelogs for issue #143.

## Testing

- Added a runtime regression test for field-binding shadowing.
- Updated compile-fail span expectations for `.await` diagnostics.