### PR TITLE
feat!: remove deprecated anonymous struct pattern syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Focus on clean design, good architecture, and comprehensive functionality rather
 - **Tuple support**: Multi-field tuples with advanced patterns `(> 10, < 30)`
 - **Method call patterns**: `field.method(): value` and `(0.method(): value, _)` for tuple elements
 - **Pattern composition**: Combine all features (e.g., `Some(> 30)`, `Event::Click(>= 0, < 100)`)
-- **Anonymous struct patterns**: Use bare `{ field: value }` to avoid imports (always non-exhaustive, `..` never required)
+- **Anonymous struct patterns**: Use `{ field: value }` to avoid imports (always non-exhaustive)
 - **Smart pointer dereferencing**: Direct pattern matching through `Box`, `Arc`, `Rc` with `*field: value`
 
 ### Improved Error Messages

--- a/assert-struct-macros/CHANGELOG.md
+++ b/assert-struct-macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- remove deprecated `_ { ... }` anonymous struct syntax and redundant trailing `..` in anonymous structs
+
 ### Fixed
 
 - prevent named struct field bindings from shadowing expected expressions ([#143](https://github.com/carllerche/assert-struct/issues/143))

--- a/assert-struct-macros/src/expand.rs
+++ b/assert-struct-macros/src/expand.rs
@@ -133,9 +133,9 @@ fn expand_struct_assertion(value_expr: &TokenStream, pattern: &PatternStruct) ->
     let fields = &pattern.fields;
     let rest = pattern.rest;
 
-    // If struct_path is None, it's a wildcard pattern - use field access
+    // Anonymous struct patterns use direct field access.
     let Some(struct_path) = struct_path.as_ref() else {
-        return expand_struct_wildcard_assertion(value_expr, fields);
+        return expand_anonymous_struct_assertion(value_expr, fields);
     };
 
     // For nested field access, we need to collect unique field names only
@@ -224,8 +224,8 @@ fn expand_struct_assertion(value_expr: &TokenStream, pattern: &PatternStruct) ->
     }
 }
 
-/// Generate wildcard struct assertion using direct field access
-fn expand_struct_wildcard_assertion(
+/// Generate an anonymous struct assertion using direct field access.
+fn expand_anonymous_struct_assertion(
     value_expr: &TokenStream,
     fields: &Punctuated<FieldAssertion, Token![,]>,
 ) -> TokenStream {

--- a/assert-struct-macros/src/expand/nodes.rs
+++ b/assert-struct-macros/src/expand/nodes.rs
@@ -292,7 +292,7 @@ pub(super) fn generate_pattern_nodes(
             let name_str = if let Some(p) = path {
                 quote! { #p }.to_string().replace(" :: ", "::")
             } else {
-                "anonymous".to_string()
+                "_".to_string()
             };
 
             let field_entries: Vec<TokenStream> = fields

--- a/assert-struct-macros/src/expand/nodes.rs
+++ b/assert-struct-macros/src/expand/nodes.rs
@@ -288,11 +288,11 @@ pub(super) fn generate_pattern_nodes(
         Pattern::Struct(PatternStruct {
             path, fields, rest, ..
         }) => {
-            // Handle wildcard struct patterns (path is None)
+            // Anonymous struct patterns have no path.
             let name_str = if let Some(p) = path {
                 quote! { #p }.to_string().replace(" :: ", "::")
             } else {
-                "_".to_string() // Use "_" for wildcard struct patterns
+                "anonymous".to_string()
             };
 
             let field_entries: Vec<TokenStream> = fields

--- a/assert-struct-macros/src/lib.rs
+++ b/assert-struct-macros/src/lib.rs
@@ -48,9 +48,10 @@ struct AssertStruct {
 /// ```text
 /// assert_struct!(expression, TypePattern);
 ///
-/// TypePattern ::= TypeName '{' FieldPatternList '}'
-///              | '{' FieldPatternList '}'            // Anonymous struct (always partial)
-/// FieldPatternList ::= (FieldPattern ',')* ('..')?
+/// TypePattern ::= TypeName '{' NamedFieldPatternList '}'
+///              | '{' AnonymousFieldPatternList '}'    // Always partial
+/// NamedFieldPatternList ::= (FieldPattern ',')* ('..')?
+/// AnonymousFieldPatternList ::= (FieldPattern ',')*
 /// FieldPattern ::= FieldName ':' Pattern
 ///              | FieldName FieldOperation ':' Pattern
 /// FieldOperation ::= ('*')+ | ('.' Identifier '(' ArgumentList? ')')
@@ -121,7 +122,7 @@ struct AssertStruct {
 ///
 /// | Pattern | Syntax | Description | Constraints |
 /// |---------|--------|-------------|-------------|
-/// | **Anonymous Struct** | `value: { fields... }` | Match struct without naming type | Always partial; `..` never required |
+/// | **Anonymous Struct** | `value: { fields... }` | Match struct without naming type | Always partial |
 /// | **Nested Anonymous** | `{ field: { ... } }` | Nested anonymous structs | Avoids importing nested types |
 ///
 /// ## Collection Patterns
@@ -165,7 +166,7 @@ struct AssertStruct {
 /// - **Without `..`**: All struct fields must be specified in the pattern (exhaustive)
 /// - **With `..`**: Only specified fields are checked (partial matching)
 /// - **Multiple `..`**: Compilation error - only one rest pattern allowed per struct
-/// - **Anonymous structs (`{ ... }`)**: Always partial — `..` is never required and may be omitted
+/// - **Anonymous structs (`{ ... }`)**: Always partial
 ///
 /// ### Field Operation Precedence
 /// Field operations are applied in left-to-right order:

--- a/assert-struct-macros/src/pattern.rs
+++ b/assert-struct-macros/src/pattern.rs
@@ -226,7 +226,7 @@ impl Pattern {
                     end.column as u32,
                 )
             }
-            // Wildcard struct patterns and plain wildcards have no meaningful location.
+            // Anonymous struct patterns and plain wildcards have no meaningful location.
             Pattern::Struct(PatternStruct { path: None, .. }) | Pattern::Wildcard(_) => {
                 (0, 0, 0, 0)
             }
@@ -248,15 +248,8 @@ impl Parse for Pattern {
 
         // Wildcard pattern: _ for ignoring a value while asserting it exists
         // Example: `Some(_)`, `field: _`, `[1, _, 3]`
-        // Special case: `_ { ... }` for wildcard struct patterns
         if input.peek(Token![_]) {
-            // Check if this is a wildcard struct pattern: `_ { ... }`
-            if input.peek2(syn::token::Brace) {
-                return Ok(Pattern::Struct(input.parse()?));
-            } else {
-                // Regular wildcard pattern
-                return Ok(Pattern::Wildcard(input.parse()?));
-            }
+            return Ok(Pattern::Wildcard(input.parse()?));
         }
 
         // Try to parse as a comparison pattern (<, <=, >, >=, ==, !=)
@@ -306,8 +299,7 @@ impl Parse for Pattern {
             return Ok(Pattern::Tuple(input.parse()?));
         }
 
-        // Bare anonymous struct pattern: { foo: "bar", .. }
-        // Shorthand for _ { foo: "bar", .. }
+        // Anonymous struct pattern: { foo: "bar" }
         if input.peek(syn::token::Brace) {
             return Ok(Pattern::Struct(input.parse()?));
         }

--- a/assert-struct-macros/src/pattern/set.rs
+++ b/assert-struct-macros/src/pattern/set.rs
@@ -26,7 +26,7 @@ impl Parse for PatternSet {
     /// ```text
     /// #(1, 2, 3)
     /// #(> 0, < 10, ..)
-    /// #(_ { kind: "click", .. }, ..)
+    /// #({ kind: "click" }, ..)
     /// ```
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         // Capture the span of the `#` token before consuming anything

--- a/assert-struct-macros/src/pattern/struct_pattern.rs
+++ b/assert-struct-macros/src/pattern/struct_pattern.rs
@@ -23,19 +23,15 @@ impl Parse for PatternStruct {
     /// # Example Input
     /// ```text
     /// User { name: "Alice", age: >= 18, .. }
-    /// { name: "Alice" }        // anonymous struct (.. implied, never required)
+    /// { name: "Alice" }        // anonymous struct (always partial)
     /// ```
     ///
-    /// Handles both named structs (with a path) and wildcard structs (starting with `_`).
+    /// Handles both named and anonymous structs.
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let node_id = next_node_id();
 
-        // Check if this is a wildcard/anonymous struct pattern: _ { ... } or { ... }
-        let path = if input.peek(Token![_]) {
-            let _: Token![_] = input.parse()?;
-            None // wildcard has no path
-        } else if input.peek(syn::token::Brace) {
-            None // bare { ... } — anonymous struct
+        let path = if input.peek(syn::token::Brace) {
+            None // anonymous struct
         } else {
             // Named struct pattern: TypeName { ... }
             Some(input.parse::<syn::Path>()?)
@@ -52,6 +48,9 @@ impl Parse for PatternStruct {
         while !content.is_empty() {
             // Check for rest pattern (..) which allows partial matching
             if content.peek(Token![..]) {
+                if path.is_none() {
+                    return Err(content.error("unexpected token in anonymous struct pattern"));
+                }
                 let _: Token![..] = content.parse()?;
                 rest = true;
                 break;
@@ -68,14 +67,16 @@ impl Parse for PatternStruct {
 
             // Rest pattern can appear after a comma
             if content.peek(Token![..]) {
+                if path.is_none() {
+                    return Err(content.error("unexpected token in anonymous struct pattern"));
+                }
                 let _: Token![..] = content.parse()?;
                 rest = true;
                 break;
             }
         }
 
-        // Wildcard struct patterns always imply partial matching since the type
-        // is unknown, so .. is never required (but still accepted if written).
+        // Anonymous struct patterns always use partial matching because their type is unknown.
         if path.is_none() {
             rest = true;
         }

--- a/assert-struct/CHANGELOG.md
+++ b/assert-struct/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- remove deprecated `_ { ... }` anonymous struct syntax and redundant trailing `..` in anonymous structs
+
 ### Fixed
 
 - prevent named struct field bindings from shadowing expected expressions ([#143](https://github.com/carllerche/assert-struct/issues/143))

--- a/assert-struct/LLM.txt
+++ b/assert-struct/LLM.txt
@@ -69,7 +69,9 @@ PATTERN GRAMMAR (informal EBNF)
                       | tuple_pat | comparison | range | equality | regex
                       | method_call | index_op | deref | closure | wildcard | expr
 
-    struct_pat      ::= (TypePath)? "{" field_assertion* ".."? "}"
+    struct_pat      ::= named_struct_pat | anonymous_struct_pat
+    named_struct_pat ::= TypePath "{" field_assertion* ".."? "}"
+    anonymous_struct_pat ::= "{" field_assertion* "}"
     field_assertion ::= field_lhs ":" pattern ","
     field_lhs       ::= IDENT ("." IDENT)*
                       | "*"+ IDENT
@@ -350,30 +352,6 @@ String literals are automatically compared without .to_string() in all contexts:
     field: ("hello", "world")
 
 Works with both String and &str field types.
-
-
-DEPRECATIONS
-
-The following syntax forms are deprecated. When encountered in existing code, update them
-to the current syntax.
-
-Anonymous struct with `_` prefix — the `_` is no longer needed for anonymous structs.
-Bare `{ ... }` is now the preferred form.
-
-    // DEPRECATED
-    assert_struct!(value, _ { field: 42 });
-
-    // CURRENT
-    assert_struct!(value, { field: 42 });
-
-Trailing `..` in anonymous structs — anonymous structs always use partial matching,
-so `..` is redundant and should be removed.
-
-    // DEPRECATED
-    assert_struct!(value, { field: 42, .. });
-
-    // CURRENT
-    assert_struct!(value, { field: 42 });
 
 
 NOT SUPPORTED — INVALID SYNTAX

--- a/assert-struct/src/lib.rs
+++ b/assert-struct/src/lib.rs
@@ -644,7 +644,7 @@
 //! ## Anonymous Struct Patterns
 //!
 //! Use anonymous struct patterns to avoid importing types while still asserting on their structure.
-//! Anonymous structs are always non-exhaustive, so `..` is never required:
+//! Anonymous structs are always non-exhaustive:
 //!
 //! ```rust
 //! # use assert_struct::assert_struct;

--- a/assert-struct/tests/await_support.rs
+++ b/assert-struct/tests/await_support.rs
@@ -110,16 +110,15 @@ async fn test_complex_nested_await() {
 }
 
 #[tokio::test]
-async fn test_wildcard_struct_with_await() {
+async fn test_anonymous_struct_with_await() {
     let data = AsyncStruct {
         async_field: AsyncValue { value: 75 },
         regular_field: "wildcard".to_string(),
     };
 
-    // Test wildcard pattern with await
-    assert_struct!(data, _ {
+    // Test anonymous struct pattern with await
+    assert_struct!(data, {
         async_field.get_value().await: 75,
-        ..
     });
 }
 

--- a/assert-struct/tests/compile_fail/nested_type_error_span.rs
+++ b/assert-struct/tests/compile_fail/nested_type_error_span.rs
@@ -69,23 +69,19 @@ fn main() {
         ret: Some("result".to_string()),
     };
 
-    assert_struct!(query_sql, _ {
-        stmt: Statement::Query(_ {
-            body: ExprSet::Select(_ {
+    assert_struct!(query_sql, {
+        stmt: Statement::Query({
+            body: ExprSet::Select({
                 source: Source::Table([
-                    _ { table: "users", .. },
+                    { table: "users" },
                 ]),
-                filter: Expr::BinaryOp(_ {
+                filter: Expr::BinaryOp({
                     *lhs: "col",
                     op: BinaryOp::Eq,
                     *rhs: == 123,  // Type error: can't compare String with integer
-                    ..
                 }),
-                ..
             }),
-            ..
         }),
         ret: Some(_),
-        ..
     });
 }

--- a/assert-struct/tests/complex_chaining.rs
+++ b/assert-struct/tests/complex_chaining.rs
@@ -198,13 +198,11 @@ async fn test_wildcard_with_complex_await() {
         },
     };
 
-    // Test wildcard patterns with complex await chains
-    assert_struct!(data, _ {
-        nested_futures: _ {
+    // Test anonymous patterns with complex await chains
+    assert_struct!(data, {
+        nested_futures: {
             // TODO: Fix this pattern - indexing issue
             // triple_future.get_future().await.as_vec().await[2]: 52, // (25 * 2) + 2 = 52
-            ..
         },
-        ..
     });
 }

--- a/assert-struct/tests/field_operations.rs
+++ b/assert-struct/tests/field_operations.rs
@@ -89,7 +89,7 @@ fn test_deref_box_with_partial_eq() {
         foo: Box::new(Bar(42)),
     };
 
-    assert_struct!(val, _ {
+    assert_struct!(val, {
         *foo: == 42u64,
     });
 }

--- a/assert-struct/tests/sets.rs
+++ b/assert-struct/tests/sets.rs
@@ -97,9 +97,9 @@ fn test_set_struct_patterns() {
     ];
 
     assert_struct!(events, #(
-        _ { kind: "hover", .. },
-        _ { kind: "click", .. },
-        _ { kind: "scroll", .. },
+        { kind: "hover" },
+        { kind: "click" },
+        { kind: "scroll" },
     ));
 }
 
@@ -122,8 +122,8 @@ fn test_set_struct_patterns_with_rest() {
 
     // Only check that click and hover are present; scroll is ignored
     assert_struct!(events, #(
-        _ { kind: "click", .. },
-        _ { kind: "hover", .. },
+        { kind: "click" },
+        { kind: "hover" },
         ..
     ));
 }

--- a/assert-struct/tests/wildcard_errors/wildcard_struct_failure.rs
+++ b/assert-struct/tests/wildcard_errors/wildcard_struct_failure.rs
@@ -23,11 +23,9 @@ pub fn test_case() {
         count: 5,
     };
 
-    assert_struct!(data, _ {
-        inner: _ {
+    assert_struct!(data, {
+        inner: {
             value: 20,  // This should fail
-            ..
         },
-        ..
     });
 }

--- a/assert-struct/tests/wildcard_struct.rs
+++ b/assert-struct/tests/wildcard_struct.rs
@@ -1,4 +1,4 @@
-/// Tests for wildcard struct patterns that avoid type imports
+/// Tests for anonymous struct patterns that avoid type imports
 use assert_struct::assert_struct;
 
 #[macro_use]
@@ -23,7 +23,7 @@ struct Complex {
 }
 
 #[test]
-fn test_wildcard_struct_simple() {
+fn test_anonymous_struct_simple() {
     let data = Outer {
         inner: Inner {
             value: 42,
@@ -32,9 +32,9 @@ fn test_wildcard_struct_simple() {
         count: 5,
     };
 
-    // Using wildcard pattern - no need to import Inner type, .. is not required
-    assert_struct!(data, _ {
-        inner: _ {
+    // No need to import the Inner type.
+    assert_struct!(data, {
+        inner: {
             value: 42,
             text: "hello",
         },
@@ -43,7 +43,7 @@ fn test_wildcard_struct_simple() {
 }
 
 #[test]
-fn test_wildcard_struct_nested() {
+fn test_anonymous_struct_nested() {
     let data = Complex {
         outer: Outer {
             inner: Inner {
@@ -56,9 +56,9 @@ fn test_wildcard_struct_nested() {
     };
 
     // Deep nesting without any type imports
-    assert_struct!(data, _ {
-        outer: _ {
-            inner: _ {
+    assert_struct!(data, {
+        outer: {
+            inner: {
                 value: > 50,
                 text: "world",
             },
@@ -69,7 +69,7 @@ fn test_wildcard_struct_nested() {
 }
 
 #[test]
-fn test_wildcard_with_comparisons() {
+fn test_anonymous_struct_with_comparisons() {
     let data = Outer {
         inner: Inner {
             value: 25,
@@ -78,8 +78,8 @@ fn test_wildcard_with_comparisons() {
         count: 8,
     };
 
-    assert_struct!(data, _ {
-        inner: _ {
+    assert_struct!(data, {
+        inner: {
             value: > 20,
             text: != "other",
         },
@@ -88,7 +88,7 @@ fn test_wildcard_with_comparisons() {
 }
 
 #[test]
-fn test_wildcard_with_method_calls() {
+fn test_anonymous_struct_with_method_calls() {
     let data = Outer {
         inner: Inner {
             value: 0,
@@ -97,8 +97,8 @@ fn test_wildcard_with_method_calls() {
         count: 3,
     };
 
-    assert_struct!(data, _ {
-        inner: _ {
+    assert_struct!(data, {
+        inner: {
             text.len(): 11,
             text.contains("world"): true,
         },
@@ -107,7 +107,7 @@ fn test_wildcard_with_method_calls() {
 }
 
 #[test]
-fn test_wildcard_partial_matching() {
+fn test_anonymous_struct_partial_matching() {
     let data = Complex {
         outer: Outer {
             inner: Inner {
@@ -119,10 +119,10 @@ fn test_wildcard_partial_matching() {
         enabled: false,
     };
 
-    // Only check specific fields, ignore the rest (.. is implicit for _ patterns)
-    assert_struct!(data, _ {
-        outer: _ {
-            inner: _ {
+    // Only check specific fields; anonymous structs are partial.
+    assert_struct!(data, {
+        outer: {
+            inner: {
                 value: 42,
             },
         },
@@ -135,7 +135,7 @@ error_message_test!(
 );
 
 #[test]
-fn test_wildcard_with_options() {
+fn test_anonymous_struct_with_options() {
     #[derive(Debug)]
     struct Container {
         maybe_inner: Option<Inner>,
@@ -148,33 +148,15 @@ fn test_wildcard_with_options() {
         }),
     };
 
-    // Combine wildcard struct with Option pattern
-    assert_struct!(data, _ {
-        maybe_inner: Some(_ {
+    // Combine an anonymous struct with an Option pattern.
+    assert_struct!(data, {
+        maybe_inner: Some({
             value: 42,
             text: "present",
         }),
     });
 }
 
-// Explicit .. is still accepted in wildcard patterns for those who prefer it
-#[test]
-fn test_wildcard_explicit_rest_still_works() {
-    let data = Outer {
-        inner: Inner {
-            value: 7,
-            text: "ok".to_string(),
-        },
-        count: 1,
-    };
-
-    assert_struct!(data, _ {
-        count: 1,
-        ..
-    });
-}
-
-// Bare anonymous struct syntax: { ... } without _ prefix
 #[test]
 fn test_bare_anonymous_struct_simple() {
     let data = Inner {
@@ -227,7 +209,7 @@ fn test_bare_anonymous_struct_partial() {
         enabled: false,
     };
 
-    // Partial matching is implicit (like _ { ... })
+    // Partial matching is implicit.
     assert_struct!(data, {
         outer: {
             inner: {
@@ -256,22 +238,6 @@ fn test_bare_anonymous_struct_with_option() {
             value: 42,
             text: "present",
         }),
-    });
-}
-
-#[test]
-fn test_bare_anonymous_struct_with_explicit_rest() {
-    let data = Outer {
-        inner: Inner {
-            value: 7,
-            text: "ok".to_string(),
-        },
-        count: 1,
-    };
-
-    assert_struct!(data, {
-        count: 1,
-        ..
     });
 }
 


### PR DESCRIPTION
## Summary

- Remove deprecated `_ { ... }` anonymous struct syntax
- Reject redundant trailing `..` in anonymous struct patterns
- Update parser documentation, changelogs, and affected tests

## Testing

Not run (not requested)