### PR TITLE
docs: remove references to the deleted examples directory

### DIFF
--- a/assert-struct-macros/CHANGELOG.md
+++ b/assert-struct-macros/CHANGELOG.md
@@ -163,6 +163,5 @@ Initial release of assert-struct - a procedural macro for ergonomic structural a
 
 #### Documentation
 - Comprehensive API documentation with examples
-- Real-world examples in `examples/` directory
 - Complete pattern reference in macro documentation
 - Comprehensive test coverage - 350+ tests across 29 test files

--- a/assert-struct-macros/src/lib.rs
+++ b/assert-struct-macros/src/lib.rs
@@ -327,7 +327,6 @@ struct AssertStruct {
 /// # See Also
 ///
 /// - **Learning Guide**: See the [crate-level documentation](crate) for comprehensive examples
-/// - **Real-World Examples**: Check the `examples/` directory for practical usage patterns
 /// - **Like Trait**: Implement custom pattern matching with the `Like` trait
 #[proc_macro]
 pub fn assert_struct(input: TokenStream) -> TokenStream {

--- a/assert-struct/CHANGELOG.md
+++ b/assert-struct/CHANGELOG.md
@@ -166,6 +166,5 @@ Initial release of assert-struct - a procedural macro for ergonomic structural a
 
 #### Documentation
 - Comprehensive API documentation with examples
-- Real-world examples in `examples/` directory
 - Complete pattern reference in macro documentation
 - Comprehensive test coverage - 350+ tests across 29 test files

--- a/assert-struct/src/lib.rs
+++ b/assert-struct/src/lib.rs
@@ -845,14 +845,6 @@
 //! assert_eq!(complex.data.as_ref().unwrap().len(), 3);
 //! ```
 //!
-//! ## Real-World Testing Patterns
-//!
-//! See the [examples directory](../../examples/) for comprehensive real-world examples including:
-//! - API response validation
-//! - Database record testing
-//! - Configuration validation
-//! - Event system testing
-//!
 //! For complete specification details, see the [`assert_struct!`] macro documentation.
 
 // Re-export the procedural macro


### PR DESCRIPTION
## Summary

- Remove outdated examples-directory references from crate documentation
- Update changelogs and macro documentation to reflect the current project layout

## Testing

Not run (not requested)